### PR TITLE
feat(#8): 라우트 세팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router": "^7.6.2",
+        "react-router-dom": "^7.6.2",
         "tailwindcss": "^4.1.10",
         "zustand": "^5.0.5"
       },
@@ -4742,6 +4743,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",
+    "react-router-dom": "^7.6.2",
     "tailwindcss": "^4.1.10",
     "zustand": "^5.0.5"
   },

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,0 +1,19 @@
+import { Outlet } from 'react-router-dom';
+
+const Layout = () => {
+  return (
+    <div>
+      <header>헤더</header>
+      <main>
+        <Outlet />
+      </main>
+      <footer>푸터</footer>
+    </div>
+  );
+};
+
+export default Layout;
+
+
+// react-router-dom 오류 뜨면 밑에 인스톨 설치해주세요
+// npm install react-router-dom 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,24 @@
+import { createBrowserRouter } from 'react-router-dom';
+import Layout from '../Layout';
+import Home from '../pages/Home';
+import NotFoundPage from '../pages/NotFoundPage';
+import publicRoutes from './PublicRoutes';
+import privateRoutes from './PrivateRoutes';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />,
+    children: [
+      { index: true, element: <Home /> },
+      ...publicRoutes,
+      ...privateRoutes,
+    ],
+  },
+  {
+    path: '*',
+    element: <NotFoundPage />,
+  },
+]);
+
+export default router;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,2 @@
+const Dashboard = () => <div>대시보드 (로그인 필요)</div>;
+export default Dashboard;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,2 @@
+const Home = () => <div>홈</div>;
+export default Home;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,2 @@
+const Login = () => <div>로그인 페이지</div>;
+export default Login;

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,2 @@
+const NotFoundPage = () => <div>404 - 페이지를 찾을 수 없습니다</div>;
+export default NotFoundPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,24 @@
+import { createBrowserRouter } from 'react-router-dom';
+import Layout from '../Layout';
+import Home from '../pages/Home';
+import NotFoundPage from '../pages/NotFoundPage';
+import publicRoutes from './publicRoutes';
+import privateRoutes from './privateRoutes';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />,
+    children: [
+      { index: true, element: <Home /> },
+      ...publicRoutes,
+      ...privateRoutes,
+    ],
+  },
+  {
+    path: '*',
+    element: <NotFoundPage />,
+  },
+]);
+
+export default router;

--- a/src/routes/privateRoutes.tsx
+++ b/src/routes/privateRoutes.tsx
@@ -1,0 +1,15 @@
+import PrivateRoute from '../routesGuard/PrivateRoute';
+import Dashboard from '../pages/Dashboard';
+
+const privateRoutes = [
+  {
+    path: '/dashboard',
+    element: (
+      <PrivateRoute>
+        <Dashboard />
+      </PrivateRoute>
+    ),
+  },
+];
+
+export default privateRoutes;

--- a/src/routes/publicRoutes.tsx
+++ b/src/routes/publicRoutes.tsx
@@ -1,0 +1,15 @@
+import PublicRoute from '../routesGuard/PublicRoute';
+import Login from '../pages/Login';
+
+const publicRoutes = [
+  {
+    path: '/login',
+    element: (
+      <PublicRoute>
+        <Login />
+      </PublicRoute>
+    ),
+  },
+];
+
+export default publicRoutes;

--- a/src/routesGuard/PrivateRoute.tsx
+++ b/src/routesGuard/PrivateRoute.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+// 예시용 로그인 여부 (실제 로직으로 대체하세요)
+const isAuthenticated = !!localStorage.getItem('token');
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const PrivateRoute = ({ children }: Props) => {
+  return isAuthenticated ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/src/routesGuard/PublicRoute.tsx
+++ b/src/routesGuard/PublicRoute.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+const isAuthenticated = !!localStorage.getItem('token');
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const PublicRoute = ({ children }: Props) => {
+  return isAuthenticated ? <Navigate to="/" replace /> : children;
+};
+
+export default PublicRoute;


### PR DESCRIPTION
✅ PR 요약
• 관련 이슈 번호: #8
• 작업 요약: 라우트 세팅

⸻

📌 상세 내용
- Layout.tsx 기본 틀 작성 (Header, Outlet, Footer 포함) 
- routes/index.tsx 생성 및 createBrowserRouter 설정
- publicRoutes, privateRoutes 라우트 파일 분리 정의
- PrivateRoute.tsx 구현 (비로그인 시 리다이렉트 처리)
- PublicRoute.tsx 구현 (로그인된 경우 접근 제한 처리)
- NotFoundPage 라우트 설정
- App.tsx에서 RouterProvider 적용 

⸻

📸 스크린샷 (선택)

⸻

📝 기타 참고 사항

⸻

🟢 PR Checklist
• 커밋 메시지 컨벤션에 맞게 작성했습니다.
• 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)