### PR TITLE
🐛 Fix(#59): MarkdownEditor 높이조절 불가로 드래그핸들러 추가 및 코드정리

### DIFF
--- a/src/components/common/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor/MarkdownEditor.tsx
@@ -1,51 +1,30 @@
-// MarkdownEditor.tsx
-// 사용방법
-// import React, { useState } from 'react';
-// import './App.css';
-// import { MarkdownEditor } from './components/common/MarkdownEditor';
-
-// function App() {
-//   const [markdownContent, setMarkdownContent] = useState(`# 안녕하세요!
-
-// **마크다운 에디터** 테스트입니다.`);
-
-//   return (
-//     <div className="min-h-screen bg-gray-50 p-8">
-//       <div className="max-w-6xl mx-auto">
-//         <h1 className="text-3xl font-bold mb-6">마크다운 에디터</h1>
-
-//         <MarkdownEditor
-//           value={markdownContent}
-//           onChange={setMarkdownContent}
-//           width="100%"
-//           height="600px"
-//         />
-//       </div>
-//     </div>
-//   );
-// }
-
-// export default App;
-
-import React, { useState, useCallback } from 'react'
-import type { MarkdownEditorProps } from './MarkdownEditor.types'
+// src/components/common/MarkdownEditor/MarkdownEditor.tsx
+import React, { useState, useRef, useCallback } from 'react'
+import { Upload, X } from 'lucide-react'
+import type { MarkdownEditorProps, ImageItem } from './MarkdownEditor.types'
 import Toolbar from './Toolbar/Toolbar'
 import Preview from './Preview/Preview'
 
 const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   value = '',
   onChange = () => {},
-  placeholder = '마크다운을 입력하세요...',
-  height = '400px',
-  width = '100%', // 기본값 100%
+  placeholder,
+  height = '500px',
+  width = '100%',
   showPreview: initialShowPreview = false,
   className = '',
 }) => {
   const [content, setContent] = useState(value)
+  const [images, setImages] = useState<ImageItem[]>([])
   const [showPreview, setShowPreview] = useState(initialShowPreview)
-  const [textareaRef, setTextareaRef] = useState<HTMLTextAreaElement | null>(
-    null
+  const [selectedImageId, setSelectedImageId] = useState<string | null>(null)
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [editorHeight, setEditorHeight] = useState(
+    parseInt(height as string) || 500
   )
+  const [isResizing, setIsResizing] = useState(false)
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const handleContentChange = useCallback(
     (newContent: string) => {
@@ -55,12 +34,19 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     [onChange]
   )
 
+  const getImageCountInMarkdown = useCallback(() => {
+    const imgTagMatches = content.match(/<img[^>]*>/g) || []
+    const markdownImgMatches = content.match(/!\[[^\]]*\]\([^)]*\)/g) || []
+    return imgTagMatches.length + markdownImgMatches.length
+  }, [content])
+
   const insertText = useCallback(
     (before: string, after: string = '') => {
-      if (!textareaRef) return
+      if (!textareaRef.current) return
 
-      const start = textareaRef.selectionStart
-      const end = textareaRef.selectionEnd
+      const textarea = textareaRef.current
+      const start = textarea.selectionStart
+      const end = textarea.selectionEnd
       const selectedText = content.substring(start, end)
 
       const newText =
@@ -72,65 +58,335 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 
       handleContentChange(newText)
 
-      // 커서 위치 조정
       setTimeout(() => {
-        if (textareaRef) {
-          const newCursorPos = start + before.length + selectedText.length
-          textareaRef.focus()
-          textareaRef.setSelectionRange(newCursorPos, newCursorPos)
-        }
+        const newCursorPos = start + before.length + selectedText.length
+        textarea.focus()
+        textarea.setSelectionRange(newCursorPos, newCursorPos)
       }, 0)
     },
-    [content, textareaRef, handleContentChange]
+    [content, handleContentChange]
   )
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.ctrlKey || e.metaKey) {
-        switch (e.key) {
-          case 'b':
-            e.preventDefault()
-            insertText('**', '**')
-            break
-          case 'i':
-            e.preventDefault()
-            insertText('*', '*')
-            break
+        const shortcuts: Record<string, () => void> = {
+          b: () => insertText('**', '**'),
+          i: () => insertText('*', '*'),
+        }
+
+        if (shortcuts[e.key]) {
+          e.preventDefault()
+          shortcuts[e.key]()
         }
       }
     },
     [insertText]
   )
 
-  return (
+  const createImageMarkdown = useCallback((imageItem: ImageItem) => {
+    return `<img src="${imageItem.url}" width="${imageItem.width}" height="${imageItem.height}" style="border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);" alt="이미지" data-image-id="${imageItem.id}" />`
+  }, [])
+
+  const insertImageMarkdown = useCallback(
+    (imageItem: ImageItem, index: number) => {
+      setTimeout(() => {
+        if (textareaRef.current) {
+          const textarea = textareaRef.current
+          const start = textarea.selectionStart
+          const end = textarea.selectionEnd
+          const markdown = createImageMarkdown(imageItem)
+
+          const newContent =
+            content.substring(0, start) +
+            '\n' +
+            markdown +
+            '\n' +
+            content.substring(end)
+
+          handleContentChange(newContent)
+
+          setTimeout(() => {
+            const newCursorPos = start + markdown.length + 2
+            textarea.focus()
+            textarea.setSelectionRange(newCursorPos, newCursorPos)
+          }, 0)
+        }
+      }, 100 * index)
+    },
+    [content, handleContentChange, createImageMarkdown]
+  )
+
+  const processImageFiles = useCallback(
+    (files: FileList) => {
+      const currentImageCount = getImageCountInMarkdown()
+
+      if (currentImageCount + files.length > 5) {
+        alert(
+          `마크다운에는 최대 5개의 이미지만 삽입할 수 있습니다. (현재 ${currentImageCount}개, 추가하려는 이미지 ${files.length}개)`
+        )
+        return
+      }
+
+      Array.from(files).forEach((file, index) => {
+        if (!file.type.startsWith('image/')) return
+
+        const imageItem: ImageItem = {
+          id: `img_${Date.now()}_${index}`,
+          file,
+          url: URL.createObjectURL(file),
+          width: 300,
+          height: 200,
+        }
+
+        setImages((prev) => [...prev, imageItem])
+        insertImageMarkdown(imageItem, index)
+      })
+    },
+    [getImageCountInMarkdown, insertImageMarkdown]
+  )
+
+  const dragHandlers = {
+    onDragOver: useCallback((e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragOver(true)
+    }, []),
+
+    onDragLeave: useCallback((e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragOver(false)
+    }, []),
+
+    onDrop: useCallback(
+      (e: React.DragEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setIsDragOver(false)
+
+        const files = e.dataTransfer.files
+        if (files.length > 0) {
+          processImageFiles(files)
+        }
+      },
+      [processImageFiles]
+    ),
+  }
+
+  const handleImageClick = useCallback((imageId: string) => {
+    setSelectedImageId(imageId)
+  }, [])
+
+  const updateImageSize = useCallback(
+    (id: string, property: 'width' | 'height', value: number) => {
+      setImages((prev) => {
+        const updated = prev.map((img) =>
+          img.id === id ? { ...img, [property]: value } : img
+        )
+
+        const targetImage = updated.find((img) => img.id === id)
+        if (targetImage) {
+          const newImageTag = createImageMarkdown(targetImage)
+          const updatedContent = content.replace(
+            new RegExp(`<img[^>]*data-image-id="${id}"[^>]*/>`, 'g'),
+            newImageTag
+          )
+          handleContentChange(updatedContent)
+        }
+
+        return updated
+      })
+    },
+    [content, handleContentChange, createImageMarkdown]
+  )
+
+  const resetImageProperties = useCallback(
+    (id: string) => {
+      updateImageSize(id, 'width', 300)
+      updateImageSize(id, 'height', 200)
+    },
+    [updateImageSize]
+  )
+
+  const closeImageModal = useCallback(() => setSelectedImageId(null), [])
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      setIsResizing(true)
+      const startY = e.clientY
+      const startHeight = editorHeight
+
+      const handleMouseMove = (e: MouseEvent) => {
+        const deltaY = e.clientY - startY
+        const newHeight = Math.max(300, Math.min(1000, startHeight + deltaY))
+        setEditorHeight(newHeight)
+      }
+
+      const handleMouseUp = () => {
+        setIsResizing(false)
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+      }
+
+      document.addEventListener('mousemove', handleMouseMove)
+      document.addEventListener('mouseup', handleMouseUp)
+    },
+    [editorHeight]
+  )
+
+  const selectedImage = selectedImageId
+    ? images.find((img) => img.id === selectedImageId)
+    : null
+
+  const ResizeHandle = () => (
     <div
-      className={`border rounded-lg overflow-hidden ${className}`}
-      style={{ width, height }}
+      className={`w-full h-2 bg-gray-200 hover:bg-gray-300 cursor-row-resize flex items-center justify-center transition-colors ${
+        isResizing ? 'bg-blue-300' : ''
+      }`}
+      onMouseDown={handleMouseDown}
     >
-      <Toolbar
-        onInsert={insertText}
-        showPreview={showPreview}
-        onTogglePreview={() => setShowPreview(!showPreview)}
-      />
+      <div className="w-8 h-1 bg-gray-400 rounded-full"></div>
+    </div>
+  )
 
-      <div className="flex" style={{ height: `calc(${height} - 50px)` }}>
-        {/* Editor - 항상 왼쪽 50% */}
-        <div className="flex-1 relative border-r border-gray-200">
-          <textarea
-            ref={setTextareaRef}
-            value={content}
-            onChange={(e) => handleContentChange(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className="w-full h-full p-4 border-none outline-none resize-none font-mono text-sm"
-          />
-        </div>
-
-        {/* Preview - 항상 오른쪽 50% */}
-        <div className="flex-1 bg-white">
-          <Preview content={content} />
+  const DragOverlay = () => (
+    <div className="absolute inset-0 bg-blue-500 bg-opacity-10 flex items-center justify-center z-10 pointer-events-none">
+      <div className="bg-white rounded-lg p-6 shadow-lg border-2 border-blue-500 border-dashed">
+        <div className="text-center">
+          <Upload size={48} className="mx-auto mb-4 text-blue-500" />
+          <p className="text-lg font-medium text-blue-700">
+            이미지를 여기에 드롭하세요
+          </p>
+          <p className="text-sm text-blue-600 mt-2">최대 5개까지 가능합니다</p>
         </div>
       </div>
+    </div>
+  )
+
+  const ImageEditModal = () => {
+    if (!selectedImage) return null
+
+    return (
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="bg-white rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[90vh] overflow-auto">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-medium">이미지 편집</h3>
+            <button
+              onClick={closeImageModal}
+              className="text-gray-500 hover:text-gray-700"
+            >
+              <X size={20} />
+            </button>
+          </div>
+
+          <div className="mb-4 text-center">
+            <img
+              src={selectedImage.url}
+              alt="편집할 이미지"
+              className="max-w-full max-h-96 mx-auto"
+              style={{
+                width: selectedImage.width,
+                height: selectedImage.height,
+              }}
+            />
+          </div>
+
+          <div className="flex gap-4 items-center justify-center flex-wrap">
+            <div className="flex items-center gap-2">
+              <label className="text-sm">너비:</label>
+              <input
+                type="number"
+                min="100"
+                max="800"
+                value={selectedImage.width || 300}
+                onChange={(e) =>
+                  updateImageSize(
+                    selectedImage.id,
+                    'width',
+                    Number(e.target.value)
+                  )
+                }
+                className="w-20 px-2 py-1 border border-gray-300 rounded text-sm"
+              />
+              <span className="text-sm">px</span>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <label className="text-sm">높이:</label>
+              <input
+                type="number"
+                min="100"
+                max="600"
+                value={selectedImage.height || 200}
+                onChange={(e) =>
+                  updateImageSize(
+                    selectedImage.id,
+                    'height',
+                    Number(e.target.value)
+                  )
+                }
+                className="w-20 px-2 py-1 border border-gray-300 rounded text-sm"
+              />
+              <span className="text-sm">px</span>
+            </div>
+
+            <div className="w-full flex gap-2 justify-center mt-4">
+              <button
+                onClick={() => resetImageProperties(selectedImage.id)}
+                className="p-2 bg-blue-100 text-blue-600 rounded hover:bg-blue-200"
+              >
+                원본 크기로 되돌리기
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className} style={{ width }}>
+      <div
+        className={`border rounded-lg overflow-hidden relative ${
+          isDragOver ? 'border-blue-500 border-2 bg-blue-50' : ''
+        }`}
+        {...dragHandlers}
+      >
+        {isDragOver && <DragOverlay />}
+
+        <Toolbar
+          onInsert={insertText}
+          showPreview={showPreview}
+          onTogglePreview={() => setShowPreview(!showPreview)}
+          onImageUpload={processImageFiles}
+        />
+
+        <div className="flex" style={{ height: `${editorHeight}px` }}>
+          <div
+            className={`${showPreview ? 'w-1/2' : 'w-full'} border-r border-gray-200`}
+          >
+            <textarea
+              ref={textareaRef}
+              value={content}
+              onChange={(e) => handleContentChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              className="w-full h-full p-4 border-none outline-none resize-none font-mono text-sm leading-relaxed"
+            />
+          </div>
+
+          {showPreview && (
+            <div className="w-1/2">
+              <Preview content={content} onImageClick={handleImageClick} />
+            </div>
+          )}
+        </div>
+
+        <ResizeHandle />
+      </div>
+
+      <ImageEditModal />
     </div>
   )
 }

--- a/src/components/common/MarkdownEditor/MarkdownEditor.types.ts
+++ b/src/components/common/MarkdownEditor/MarkdownEditor.types.ts
@@ -7,7 +7,7 @@ export interface MarkdownEditorProps {
   onChange?: (value: string) => void
   placeholder?: string
   height?: string
-  width?: string // 가로 크기 추가
+  width?: string
   showPreview?: boolean
   className?: string
 }
@@ -23,8 +23,18 @@ export interface ToolbarProps {
   onInsert: (before: string, after?: string) => void
   showPreview: boolean
   onTogglePreview: () => void
+  onImageUpload?: (files: FileList) => void
 }
 
 export interface PreviewProps {
   content: string
+  onImageClick?: (imageId: string) => void
+}
+
+export interface ImageItem {
+  id: string
+  file: File
+  url: string
+  width?: number
+  height?: number
 }

--- a/src/components/common/MarkdownEditor/Preview/Preview.tsx
+++ b/src/components/common/MarkdownEditor/Preview/Preview.tsx
@@ -1,58 +1,162 @@
-// Preview/Preview.tsx
-
+// src/components/common/MarkdownEditor/Preview/Preview.tsx
 import React from 'react'
-import type { PreviewProps } from '../MarkdownEditor.types'
 
-const Preview: React.FC<PreviewProps> = ({ content }) => {
-  // 간단한 마크다운 파싱 (실제로는 react-markdown 사용 권장)
+interface PreviewProps {
+  content: string
+  onImageClick?: (imageId: string) => void
+}
+
+const Preview: React.FC<PreviewProps> = ({ content, onImageClick }) => {
+  const parseInlineMarkdown = (text: string): string => {
+    return text
+      .replace(/<img([^>]*)>/g, '<img$1>')
+      .replace(
+        /!\[([^\]]*?)\]\(([^)]*?)\)/g,
+        '<img alt="$1" src="$2" style="max-width:100%;height:auto;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);" />'
+      )
+      .replace(
+        /\[([^\]]+?)\]\(([^)]+?)\)/g,
+        '<a href="$2" class="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">$1</a>'
+      )
+      .replace(/\*\*(.*?)\*\*/g, '<strong class="font-bold">$1</strong>')
+      .replace(/\*(.*?)\*/g, '<em class="italic">$1</em>')
+      .replace(
+        /`([^`]+?)`/g,
+        '<code class="bg-gray-100 px-1 rounded text-sm">$1</code>'
+      )
+  }
+
+  const parseHeading = (line: string): string | null => {
+    if (line.startsWith('###'))
+      return `<h3 class="text-lg font-semibold mt-4 mb-2">${parseInlineMarkdown(line.substring(3).trim())}</h3>`
+    if (line.startsWith('##'))
+      return `<h2 class="text-xl font-semibold mt-4 mb-2">${parseInlineMarkdown(line.substring(2).trim())}</h2>`
+    if (line.startsWith('#'))
+      return `<h1 class="text-2xl font-bold mt-4 mb-2">${parseInlineMarkdown(line.substring(1).trim())}</h1>`
+    return null
+  }
+
+  const parseListItem = (
+    line: string
+  ): { type: 'numbered' | 'bullet' | null; content: string } => {
+    const numbered = line.match(/^(\d+)\.\s+(.+)/)
+    const bullet = line.match(/^[-*]\s+(.+)/)
+
+    if (numbered) return { type: 'numbered', content: numbered[2] }
+    if (bullet) return { type: 'bullet', content: bullet[1] }
+    return { type: null, content: '' }
+  }
+
+  const getListTag = (
+    type: 'numbered' | 'bullet'
+  ): { tag: string; class: string } => {
+    return type === 'numbered'
+      ? { tag: 'ol', class: 'list-decimal list-inside' }
+      : { tag: 'ul', class: 'list-disc list-inside' }
+  }
+
   const parseMarkdown = (text: string): string => {
-    return (
-      text
-        // Headers
-        .replace(/^### (.*$)/gim, '<h3>$1</h3>')
-        .replace(/^## (.*$)/gim, '<h2>$1</h2>')
-        .replace(/^# (.*$)/gim, '<h1>$1</h1>')
-        // Bold
-        .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-        // Italic
-        .replace(/\*(.*?)\*/g, '<em>$1</em>')
-        // Code
-        .replace(
-          /`([^`]+?)`/g,
-          '<code class="bg-gray-100 px-1 rounded">$1</code>'
-        )
-        // Links
-        .replace(
-          /\[([^\]]*?)\]\(([^)]*?)\)/g,
-          '<a href="$2" class="text-blue-600 hover:underline">$1</a>'
-        )
-        // Images
-        .replace(
-          /!\[([^\]]*?)\]\(([^)]*?)\)/g,
-          '<img alt="$1" src="$2" class="max-w-full h-auto" />'
-        )
-        // Lists
-        .replace(/^- (.+$)/gim, '<li>$1</li>')
-        .replace(/^(\d+)\. (.+$)/gim, '<li>$1. $2</li>')
-        // Blockquotes
-        .replace(
-          /^> (.+$)/gim,
-          '<blockquote class="border-l-4 border-gray-300 pl-4 italic">$1</blockquote>'
-        )
-        // Line breaks
-        .replace(/\n/gim, '<br>')
-    )
+    if (!text)
+      return '<p class="text-gray-400">미리보기가 여기에 표시됩니다...</p>'
+
+    // 상태추적역할,const사용하면 assignment to constant variable 에러 -> 공부할것
+    const lines = text.split('\n')
+    let html = ''
+    let inCodeBlock = false
+    let inList = false
+    let currentListType: 'numbered' | 'bullet' | null = null
+
+    lines.forEach((line) => {
+      // 코드 블록 처리
+      if (line.startsWith('```')) {
+        if (inCodeBlock) {
+          html += '</code></pre>'
+          inCodeBlock = false
+        } else {
+          const lang = line.substring(3).trim()
+          html += `<pre class="bg-gray-100 p-4 rounded overflow-x-auto my-4"><code class="language-${lang}">`
+          inCodeBlock = true
+        }
+        return
+      }
+
+      if (inCodeBlock) {
+        html += line + '\n'
+        return
+      }
+
+      const listItem = parseListItem(line)
+      if (listItem.type) {
+        if (!inList || currentListType !== listItem.type) {
+          if (inList) {
+            const prevTag = getListTag(currentListType!)
+            html += `</${prevTag.tag}>`
+          }
+          inList = true
+          currentListType = listItem.type
+          const { tag, class: listClass } = getListTag(listItem.type)
+          html += `<${tag} class="${listClass} space-y-1 my-4">`
+        }
+        html += `<li>${parseInlineMarkdown(listItem.content)}</li>`
+        return
+      }
+
+      if (inList) {
+        const { tag } = getListTag(currentListType!)
+        html += `</${tag}>`
+        inList = false
+        currentListType = null
+      }
+
+      if (line.trim() === '') {
+        html += '<br>'
+        return
+      }
+
+      if (line.includes('<img')) {
+        html += `<div class="my-2">${line.replace(/class="[^"]*"/g, '')}</div>`
+        return
+      }
+
+      const heading = parseHeading(line)
+      if (heading) {
+        html += heading
+        return
+      }
+
+      if (line.startsWith('>')) {
+        html += `<blockquote class="border-l-4 border-gray-300 pl-4 italic text-gray-600 my-2">${parseInlineMarkdown(line.substring(2))}</blockquote>`
+        return
+      }
+
+      html += `<p class="mb-2">${parseInlineMarkdown(line)}</p>`
+    })
+
+    if (inList && currentListType) {
+      const { tag } = getListTag(currentListType)
+      html += `</${tag}>`
+    }
+
+    return html
+  }
+
+  const handleImageClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement
+    if (target.tagName === 'IMG') {
+      const imageId = target.getAttribute('data-image-id')
+      if (imageId && onImageClick) {
+        onImageClick(imageId)
+      }
+    }
   }
 
   return (
-    <div
-      className="p-4 h-full overflow-auto prose prose-sm max-w-none"
-      dangerouslySetInnerHTML={{
-        __html: content
-          ? parseMarkdown(content)
-          : '<p class="text-gray-400">미리보기가 여기에 표시됩니다...</p>',
-      }}
-    />
+    <div className="p-4 h-full overflow-auto prose prose-sm max-w-none">
+      <div
+        dangerouslySetInnerHTML={{ __html: parseMarkdown(content) }}
+        onClick={handleImageClick}
+      />
+    </div>
   )
 }
 

--- a/src/components/common/MarkdownEditor/Toolbar/Toolbar.tsx
+++ b/src/components/common/MarkdownEditor/Toolbar/Toolbar.tsx
@@ -1,77 +1,146 @@
-// Toolbar/Toolbar.tsx
-
-import React from 'react'
+// Toolbar.tsx
+import React, { useRef } from 'react'
 import {
+  Upload,
   Bold,
   Italic,
   Link,
-  Image,
-  List,
-  ListOrdered,
-  Quote,
   Code,
+  List,
   Eye,
-  Edit,
+  EyeOff,
+  Heading1,
+  Heading2,
+  Heading3,
 } from 'lucide-react'
 import type { ToolbarProps } from '../MarkdownEditor.types'
 import ToolbarButton from './ToolbarButton'
+
+interface ToolButton {
+  icon: React.ReactNode
+  title: string
+  onClick: () => void
+}
 
 const Toolbar: React.FC<ToolbarProps> = ({
   onInsert,
   showPreview,
   onTogglePreview,
-}) => (
-  <div className="flex items-center gap-1 p-2 border-b bg-gray-50 rounded-t-lg">
-    <ToolbarButton
-      icon={<Bold size={16} />}
-      title="Bold (Ctrl+B)"
-      onClick={() => onInsert('**', '**')}
-    />
-    <ToolbarButton
-      icon={<Italic size={16} />}
-      title="Italic (Ctrl+I)"
-      onClick={() => onInsert('*', '*')}
-    />
-    <div className="w-px h-6 bg-gray-300 mx-1" />
-    <ToolbarButton
-      icon={<Link size={16} />}
-      title="Link"
-      onClick={() => onInsert('[', '](url)')}
-    />
-    <ToolbarButton
-      icon={<Image size={16} />}
-      title="Image"
-      onClick={() => onInsert('![alt](', ')')}
-    />
-    <div className="w-px h-6 bg-gray-300 mx-1" />
-    <ToolbarButton
-      icon={<List size={16} />}
-      title="Bullet List"
-      onClick={() => onInsert('- ')}
-    />
-    <ToolbarButton
-      icon={<ListOrdered size={16} />}
-      title="Numbered List"
-      onClick={() => onInsert('1. ')}
-    />
-    <ToolbarButton
-      icon={<Quote size={16} />}
-      title="Quote"
-      onClick={() => onInsert('> ')}
-    />
-    <ToolbarButton
-      icon={<Code size={16} />}
-      title="Code"
-      onClick={() => onInsert('`', '`')}
-    />
-    <div className="flex-1" />
-    <ToolbarButton
-      icon={showPreview ? <Edit size={16} /> : <Eye size={16} />}
-      title={showPreview ? '편집 모드로 전환' : '미리보기 모드로 전환'}
-      onClick={onTogglePreview}
-      isActive={showPreview}
-    />
-  </div>
-)
+  onImageUpload,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleImageUploadClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && onImageUpload) {
+      onImageUpload(e.target.files)
+    }
+  }
+
+  const headingButtons: ToolButton[] = [
+    {
+      icon: <Heading1 size={16} />,
+      title: 'Heading 1',
+      onClick: () => onInsert('# '),
+    },
+    {
+      icon: <Heading2 size={16} />,
+      title: 'Heading 2',
+      onClick: () => onInsert('## '),
+    },
+    {
+      icon: <Heading3 size={16} />,
+      title: 'Heading 3',
+      onClick: () => onInsert('### '),
+    },
+  ]
+
+  const formatButtons: ToolButton[] = [
+    {
+      icon: <Bold size={16} />,
+      title: 'Bold (Ctrl+B)',
+      onClick: () => onInsert('**', '**'),
+    },
+    {
+      icon: <Italic size={16} />,
+      title: 'Italic (Ctrl+I)',
+      onClick: () => onInsert('*', '*'),
+    },
+    {
+      icon: <Link size={16} />,
+      title: 'Link',
+      onClick: () => onInsert('[링크텍스트](URL)'),
+    },
+    {
+      icon: <Code size={16} />,
+      title: 'Code',
+      onClick: () => onInsert('`', '`'),
+    },
+    {
+      icon: <List size={16} />,
+      title: 'List',
+      onClick: () => onInsert('- '),
+    },
+  ]
+
+  const Divider = () => <div className="w-px h-6 bg-gray-300 mx-2" />
+
+  return (
+    <div className="bg-gray-50 border-b p-2 flex items-center gap-2 flex-wrap">
+      {headingButtons.map((button, index) => (
+        <ToolbarButton
+          key={`heading-${index}`}
+          icon={button.icon}
+          title={button.title}
+          onClick={button.onClick}
+        />
+      ))}
+
+      <Divider />
+
+      {formatButtons.map((button, index) => (
+        <ToolbarButton
+          key={`format-${index}`}
+          icon={button.icon}
+          title={button.title}
+          onClick={button.onClick}
+        />
+      ))}
+
+      <Divider />
+
+      <ToolbarButton
+        icon={<Upload size={16} />}
+        title="Upload Image"
+        onClick={handleImageUploadClick}
+      >
+        <span className="text-sm">이미지 (드래그앤드롭 가능)</span>
+      </ToolbarButton>
+
+      <Divider />
+
+      <ToolbarButton
+        icon={showPreview ? <EyeOff size={16} /> : <Eye size={16} />}
+        title="Toggle Preview"
+        onClick={onTogglePreview}
+        isActive={showPreview}
+      >
+        <span className="text-sm">미리보기</span>
+      </ToolbarButton>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/*"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+    </div>
+  )
+}
 
 export default Toolbar

--- a/src/components/common/MarkdownEditor/Toolbar/ToolbarButton.tsx
+++ b/src/components/common/MarkdownEditor/Toolbar/ToolbarButton.tsx
@@ -1,23 +1,30 @@
-// Toolbar/ToolbarButton.tsx
-
+// ToolbarButton.tsx
 import React from 'react'
-import type { ToolbarButtonProps } from '../MarkdownEditor.types'
+
+interface ToolbarButtonProps {
+  icon: React.ReactNode
+  title: string
+  onClick: () => void
+  isActive?: boolean
+  children?: React.ReactNode
+}
 
 const ToolbarButton: React.FC<ToolbarButtonProps> = ({
   icon,
   title,
   onClick,
   isActive = false,
+  children,
 }) => (
   <button
     onClick={onClick}
     title={title}
-    className={`
-      p-2 rounded hover:bg-gray-100 transition-colors
-      ${isActive ? 'bg-blue-100 text-blue-600' : 'text-gray-600'}
-    `}
+    className={`p-2 rounded transition-colors flex items-center gap-1 ${
+      isActive ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200 text-gray-600'
+    }`}
   >
     {icon}
+    {children}
   </button>
 )
 


### PR DESCRIPTION
## 🔧 관련 이슈
- 이 PR은 다음 이슈와 관련 있습니다: #59

## 🔄 변경 사항
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링

## ✔️ 변경 사항 상세 설명
- 변경된 파일: 
  - `src/components/common/MarkdownEditor/MarkdownEditor.tsx`
  - `src/components/common/MarkdownEditor/Toolbar/Toolbar.tsx`
  - `src/components/common/MarkdownEditor/Toolbar/ToolbarButton.tsx`
  - `src/components/common/MarkdownEditor/MarkdownEditor.types.ts`
  - `src/components/common/MarkdownEditor/Preview/Preview.tsx`

- 주요 구현/수정 내용:
  - 이미지 드래그앤드롭 기능 추가 (dragHandlers)
  - 이미지 크기 변경 기능 추가 (updateImageSize, resetImageProperties)
  - 에디터 높이 조절을 위한 리사이즈 드래그 핸들 추가 (handleMouseDown)
  - ToolbarButton 컴포넌트 분리하여 재사용성 향상
  - 불필요한 주석 제거 및 코드 간결화
  - 사용하지 않는 타입 정의 정리


## ⚠️ 기타 주의 사항
- 기존 기능은 모두 유지되며, 새로운 드래그 기능들이 추가되었습니다
- 코드 정리로 인한 가독성 향상, 기능 변경 없음

## 💡 사용법

```typescript
// 파일 위치에 따라 상대경로 조정 필요
import MarkdownEditor from '../../components/common/MarkdownEditor' (절대경로 설정하면 편할듯합니다.)

const [content, setContent] = useState('')

<MarkdownEditor
  value={content}
  onChange={setContent}
  placeholder="내용을 입력하세요..."
  height="600px"
  showPreview={true}
/>
```