### PR TITLE
refactor(#74): 질의응답 리스트 기능 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import HomePage from './pages/index'
 import Layout from './pages/Layout'
+import QnaListPage from './pages/QnaListPage'
 import QnaDetailPage from './pages/QnaDetailPage'
 
 function App() {
@@ -9,6 +10,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<HomePage />} />
+          <Route path="/qna" element={<QnaListPage />} />
           <Route path="qna/:id" element={<QnaDetailPage />} />
         </Route>
       </Routes>

--- a/src/components/Mocks/MockQnaListResponse.ts
+++ b/src/components/Mocks/MockQnaListResponse.ts
@@ -1,0 +1,100 @@
+// mocks/mockQnaListResponse2.ts
+
+export const mockQnaListResponse = {
+  count: 5,
+  next: null,
+  previous: null,
+  results: [
+    {
+      id: 1,
+      title: 'Django 마이그레이션 질문입니다',
+      content: 'makemigrations 이후 migrate 시 오류가 납니다.',
+      author: {
+        nickname: 'oz_student',
+        profile_image_url: 'https://cdn.ozcoding.com/profile/oz_student.jpg',
+      },
+      category: {
+        depth_1: '웹개발',
+        depth_2: 'Django',
+        depth_3: '오류 해결',
+      },
+      answer_count: 3,
+      view_count: 123,
+      created_at: '2025-06-23T02:22:00Z',
+      thumbnail: ' ',
+    },
+    {
+      id: 2,
+      title: 'React 상태관리 관련 질문입니다',
+      content: 'useState와 Redux의 차이점이 궁금합니다.',
+      author: {
+        nickname: 'frontend_dev',
+        profile_image_url: 'https://cdn.ozcoding.com/profile/frontend_dev.jpg',
+      },
+      category: {
+        depth_1: '웹개발',
+        depth_2: 'React',
+        depth_3: '상태관리',
+      },
+      answer_count: 1,
+      view_count: 78,
+      created_at: '2025-06-25T14:12:00Z',
+      thumbnail: 'https://cdn.ozcoding.com/media/questions/2/thumb.jpg',
+    },
+    {
+      id: 3,
+      title: 'Python 반복문 관련 오류',
+      content: 'for문에서 인덱스 오류가 발생합니다. 해결 방법이 있을까요?',
+      author: {
+        nickname: 'python_lover',
+        profile_image_url: 'https://cdn.ozcoding.com/profile/python_lover.jpg',
+      },
+      category: {
+        depth_1: '프로그래밍 언어',
+        depth_2: 'Python',
+        depth_3: '문법',
+      },
+      answer_count: 0,
+      view_count: 45,
+      created_at: '2025-06-27T09:00:00Z',
+      thumbnail: '',
+    },
+    {
+      id: 4,
+      title: 'Next.js에서 페이지 전환 시 데이터 유지하는 방법은?',
+      content:
+        'getServerSideProps로 받아온 데이터를 페이지 전환 후에도 유지하고 싶습니다.',
+      author: {
+        nickname: 'nextjs_master',
+        profile_image_url: 'https://cdn.ozcoding.com/profile/nextjs_master.jpg',
+      },
+      category: {
+        depth_1: '웹개발',
+        depth_2: 'Next.js',
+        depth_3: '데이터 처리',
+      },
+      answer_count: 2,
+      view_count: 98,
+      created_at: '2025-06-28T17:20:00Z',
+      thumbnail: '',
+    },
+    {
+      id: 5,
+      title: '백엔드 API 응답이 너무 느립니다',
+      content: '서버 응답 시간이 오래 걸리는 이유가 뭘까요?',
+      author: {
+        nickname: 'api_debugger',
+        profile_image_url: 'https://cdn.ozcoding.com/profile/api_debugger.jpg',
+      },
+      category: {
+        depth_1: '백엔드',
+        depth_2: 'FastAPI',
+        depth_3: '성능 최적화',
+      },
+      answer_count: 4,
+      view_count: 250,
+      created_at: '2025-06-30T08:30:00Z',
+      thumbnail: 'https://cdn.ozcoding.com/media/questions/5/thumb.jpg',
+    },
+  ],
+}

--- a/src/components/qna/QnaCard.tsx
+++ b/src/components/qna/QnaCard.tsx
@@ -1,116 +1,101 @@
 import type { FC } from 'react'
+import { Link } from 'react-router-dom'
 import userAvatar from '../../assets/images/common/img_user_default.png'
-
-type Question = {
-  id: number
-  title: string
-  content: string
-  category: string
-  subCategory: string
-  language: string
-  answerCount: number
-  viewCount: number
-  nickname: string
-  time: string
-  thumbnail?: string
-}
+import defaultThumbnail from '../../assets/images/thumbnail.png'
+import type { QuestionCard } from '../../types/qnaCard.types'
+import { highlightText } from '../../utils/highlightText'
 
 type QnaCardProps = {
-  question: Question
+  question: QuestionCard
   query?: string
-}
-
-// ✅ 검색어 하이라이트 유틸
-const highlightText = (text: string, keyword: string) => {
-  if (!keyword) return text
-  const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const regex = new RegExp(`(${escapedKeyword})`, 'gi')
-  return text.split(regex).map((part, idx) =>
-    regex.test(part) ? (
-      <span key={idx} className="text-[#6201E0] font-semibold">
-        {part}
-      </span>
-    ) : (
-      part
-    )
-  )
 }
 
 const QnaCard: FC<QnaCardProps> = ({ question, query = '' }) => {
   return (
-    <div className="flex flex-col p-6 mb-4 duration-300 hover:bg-[#FAFAFA] rounded-lg transition-colors">
-      {/* 상단 영역 */}
-      <div className="flex justify-between">
-        {/* 왼쪽 텍스트 */}
-        <div className="flex-1 pr-5">
-          <div className="font-medium text-gray-600 text-xs mb-5">
-            <span>{question.category}</span>
-            <span className="mx-1">&gt;</span>
-            <span>{question.subCategory}</span>
-            <span className="mx-1">&gt;</span>
-            <span className="border-b border-gray-400 pb-px">
-              {question.language}
+    <Link
+      to={`/qna/${question.id}`}
+      className="block"
+      aria-label={`상세페이지로 이동: ${question.title}`}
+    >
+      <div className="flex flex-col p-6 mb-5 duration-300 hover:bg-[#FAFAFA] rounded-lg transition-colors">
+        {/* 상단 영역 */}
+        <div className="flex justify-between">
+          {/* 왼쪽 텍스트 */}
+          <div className="flex-1 pr-5">
+            <div className="font-medium text-gray-600 text-xs mb-5">
+              <span>{question.category}</span>
+              <span className="mx-1">&gt;</span>
+              <span>{question.subCategory}</span>
+              <span className="mx-1">&gt;</span>
+              <span className="border-b border-gray-400 pb-px">
+                {question.language}
+              </span>
+            </div>
+
+            <h2 className="text-headline-sb text-gray-600 mb-5 line-clamp-2">
+              {highlightText(question.title, query)}
+            </h2>
+
+            <p className="mb-5 text-sm text-gray-400 leading-relaxed line-clamp-3">
+              {highlightText(question.content, query)}
+            </p>
+          </div>
+
+          {/* 썸네일 (존재할 때만) */}
+          {question.thumbnail && (
+            <div className="ml-5 shrink-0">
+              <img
+                src={question.thumbnail}
+                alt="Question Thumbnail"
+                className="w-[228px] h-[163px] object-cover rounded-md"
+                onError={(e) => {
+                  const target = e.target as HTMLImageElement
+                  target.onerror = null
+                  target.src = defaultThumbnail
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* 하단 영역 */}
+        <div className="flex justify-between items-center mt-6 text-sm text-gray-400">
+          {/* 답변/조회수 + A 뱃지 */}
+          <div className="flex items-center gap-[9px]">
+            <div
+              className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold
+                ${question.answerCount > 0 ? 'bg-[#04C73D] text-white' : 'bg-[#bdbdbd] text-white'}
+              `}
+            >
+              A
+            </div>
+            <span
+              className={`text-tag-md font-semibold ${
+                question.answerCount > 0 ? 'text-gray-600' : 'text-gray-400'
+              }`}
+            >
+              답변 {question.answerCount}
+            </span>
+            <span className="text-tag-md text-gray-400 font-semibold">
+              조회수 {question.viewCount}
             </span>
           </div>
 
-          <h2 className="text-headline-sb text-gray-600 mb-5 line-clamp-2">
-            {highlightText(question.title, query)}
-          </h2>
-
-          <p className="mb- text-sm text-gray-400 leading-relaxed line-clamp-3">
-            {highlightText(question.content, query)}
-          </p>
-        </div>
-
-        {/* 썸네일 */}
-        {question.thumbnail && (
-          <div className="ml-5 shrink-0">
+          {/* 작성자 정보 */}
+          <div className="flex items-center h-6">
             <img
-              src={question.thumbnail}
-              alt="Question Thumbnail"
-              className="w-[228px] h-[163px] object-cover rounded-md"
+              src={userAvatar}
+              alt="user avatar"
+              className="w-6 h-6 rounded-full mr-2"
             />
+            <span className="text-gray-400 text-xs font-semibold">
+              {question.nickname}
+            </span>
+            <span className="ml-2 text-gray-400 text-xs">{question.time}</span>
           </div>
-        )}
-      </div>
-
-      {/* 하단 영역 */}
-      <div className="flex justify-between items-center mt-6 text-sm text-gray-400">
-        {/* 답변/조회수 + A 뱃지 */}
-        <div className="flex items-center gap-[9px]">
-          <div
-            className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold
-              ${question.answerCount > 0 ? 'bg-[#04C73D] text-white' : 'bg-[#bdbdbd] text-white'}
-            `}
-          >
-            A
-          </div>
-          <span
-            className={`text-tag-md font-semibold ${
-              question.answerCount > 0 ? 'text-gray-600' : 'text-gray-400'
-            }`}
-          >
-            답변 {question.answerCount}
-          </span>
-          <span className="text-tag-md text-gray-400 font-semibold">
-            조회수 {question.viewCount}
-          </span>
-        </div>
-
-        {/* 작성자 정보 */}
-        <div className="flex items-center h-6">
-          <img
-            src={userAvatar}
-            alt="user avatar"
-            className="w-6 h-6 rounded-full mr-2"
-          />
-          <span className="text-gray-400 text-xs font-semibold">
-            {question.nickname}
-          </span>
-          <span className="ml-2 text-gray-400 text-xs">{question.time}</span>
         </div>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/src/components/qna/QnaFilterModal.tsx
+++ b/src/components/qna/QnaFilterModal.tsx
@@ -3,22 +3,18 @@ import { X } from 'lucide-react'
 import SingleDropdown from '../common/SingleDropdown'
 import Button from '../common/Button/Button'
 import rotateIcon from '../../assets/icons/rotate-cw.svg'
-
-type Filters = {
-  category1: string
-  category2: string
-  category3: string
-}
+import { CATEGORY, DEFAULT_CATEGORY } from '../qna/category'
+import type { CategoryFilter } from '../../../src/types/qnaFilters.types'
 
 type Props = {
   onClose: () => void
-  onApply: (filters: Filters) => void
+  onApply: (filters: CategoryFilter) => void
 }
 
 const QnaFilterModal: React.FC<Props> = ({ onClose, onApply }) => {
-  const [category1, setCategory1] = useState('대분류')
-  const [category2, setCategory2] = useState('중분류')
-  const [category3, setCategory3] = useState('소분류')
+  const [main, setMain] = useState(DEFAULT_CATEGORY.main)
+  const [sub, setSub] = useState(DEFAULT_CATEGORY.sub)
+  const [detail, setDetail] = useState(DEFAULT_CATEGORY.detail)
 
   useEffect(() => {
     document.body.style.overflow = 'hidden'
@@ -27,41 +23,31 @@ const QnaFilterModal: React.FC<Props> = ({ onClose, onApply }) => {
     }
   }, [])
 
-  const handleCategoryChange = (selected: string) => {
-    setCategory1(selected)
-    setCategory2('중분류')
-    setCategory3('소분류')
-  }
-
-  const handleSubCategoryChange = (selected: string) => {
-    setCategory2(selected)
-    setCategory3('소분류')
-  }
-
   const resetFilters = () => {
-    setCategory1('대분류')
-    setCategory2('중분류')
-    setCategory3('소분류')
+    setMain(DEFAULT_CATEGORY.main)
+    setSub(DEFAULT_CATEGORY.sub)
+    setDetail(DEFAULT_CATEGORY.detail)
   }
 
-  const category1Options = ['프론트엔드', '백엔드', 'Select 03', 'Select 04']
-  const category2Options = [
-    '프로그래밍 언어',
-    '웹 프레임워크',
-    'Web',
-    'OS',
-    '라이브러리',
-  ]
-  const category3Options = [
-    'JavaScript',
-    'Python',
-    'React',
-    'Django',
-    'FastAPI',
-  ]
+  const mainOptions = Object.keys(CATEGORY) as (keyof typeof CATEGORY)[]
+  type MainKey = keyof typeof CATEGORY
+  type SubKey = keyof (typeof CATEGORY)[MainKey]
 
-  const isSubCategoryDisabled = category1 === '대분류'
-  const isSubSubCategoryDisabled = category2 === '중분류'
+  const subOptions =
+    main && (main as MainKey) in CATEGORY
+      ? Object.keys(CATEGORY[main as MainKey])
+      : []
+
+  const detailOptions =
+    main &&
+    sub &&
+    (main as MainKey) in CATEGORY &&
+    (sub as SubKey) in CATEGORY[main as MainKey]
+      ? CATEGORY[main as MainKey][sub as SubKey]
+      : []
+
+  const isSubDisabled = main === DEFAULT_CATEGORY.main
+  const isDetailDisabled = sub === DEFAULT_CATEGORY.sub
 
   return (
     <div className="fixed inset-0 z-50 flex">
@@ -90,43 +76,33 @@ const QnaFilterModal: React.FC<Props> = ({ onClose, onApply }) => {
 
             <div className="flex flex-col gap-4">
               <SingleDropdown
-                options={category1Options}
+                options={mainOptions}
                 placeholder="대분류"
-                onChange={handleCategoryChange}
-                styleConfig={{
-                  bgColor: '#fff',
-                  borderColor: '#ccc',
-                  hoverBgColor: '#EFE6FC',
-                  selectedTextColor: '#6200E0',
+                selected={main}
+                onChange={(selected) => {
+                  setMain(selected)
+                  setSub(DEFAULT_CATEGORY.sub)
+                  setDetail(DEFAULT_CATEGORY.detail)
                 }}
               />
 
               <SingleDropdown
-                options={category2Options}
+                options={subOptions}
                 placeholder="중분류"
-                onChange={handleSubCategoryChange}
-                disabled={isSubCategoryDisabled}
-                styleConfig={{
-                  bgColor: isSubCategoryDisabled ? '#f0f0f0' : '#fff',
-                  borderColor: '#ccc',
-                  hoverBgColor: '#EFE6FC',
-                  selectedTextColor: '#6200E0',
-                  disabledBgColor: '#f0f0f0',
+                selected={sub}
+                onChange={(selected) => {
+                  setSub(selected)
+                  setDetail(DEFAULT_CATEGORY.detail)
                 }}
+                disabled={isSubDisabled}
               />
 
               <SingleDropdown
-                options={category3Options}
+                options={detailOptions}
                 placeholder="소분류"
-                onChange={setCategory3}
-                disabled={isSubSubCategoryDisabled}
-                styleConfig={{
-                  bgColor: isSubSubCategoryDisabled ? '#f0f0f0' : '#fff',
-                  borderColor: '#ccc',
-                  hoverBgColor: '#EFE6FC',
-                  selectedTextColor: '#6200E0',
-                  disabledBgColor: '#f0f0f0',
-                }}
+                selected={detail}
+                onChange={(selected) => setDetail(selected)}
+                disabled={isDetailDisabled}
               />
             </div>
           </div>
@@ -153,12 +129,9 @@ const QnaFilterModal: React.FC<Props> = ({ onClose, onApply }) => {
 
           <Button
             variant="fill"
-            width="278px"
-            height="54px"
-            fontSize="20px"
-            radius="4px"
+            className="w-[278px] h-[54px] text-[20px] rounded-[4px]"
             onClick={() => {
-              onApply({ category1, category2, category3 })
+              onApply({ main, sub, detail })
               onClose()
             }}
           >

--- a/src/components/qna/QnaSearch.tsx
+++ b/src/components/qna/QnaSearch.tsx
@@ -66,16 +66,11 @@ const QnaSearch = ({ query, setQuery }: Props) => {
 
       <Button
         variant="fill"
-        width="126px"
-        height="48px"
-        fontSize="16px"
-        radius="4px"
+        className="w-[126px] h-[48px] text-[16px] rounded-[4px] flex items-center justify-center gap-2"
         onClick={() => console.log('질문하기 클릭')}
       >
-        <div className="flex items-center justify-center gap-2 cursor-pointer">
-          <img src={pencilIcon} alt="질문하기" className="w-[20px] h-[20px]" />
-          질문하기
-        </div>
+        <img src={pencilIcon} alt="질문하기" className="w-[20px] h-[20px]" />
+        <span className="whitespace-nowrap">질문하기</span>
       </Button>
     </div>
   )

--- a/src/components/qna/category.ts
+++ b/src/components/qna/category.ts
@@ -1,0 +1,16 @@
+export const CATEGORY = {
+  프론트엔드: {
+    '프로그래밍 언어': ['JavaScript', 'TypeScript'],
+    '웹 프레임워크': ['React', 'Vue'],
+  },
+  백엔드: {
+    '프로그래밍 언어': ['Python', 'Java'],
+    '웹 프레임워크': ['Django', 'FastAPI'],
+  },
+}
+
+export const DEFAULT_CATEGORY = {
+  main: '대분류',
+  sub: '중분류',
+  detail: '소분류',
+}

--- a/src/pages/QnaListPage.tsx
+++ b/src/pages/QnaListPage.tsx
@@ -1,67 +1,35 @@
-// QnaListPage.tsx
 import React, { useState } from 'react'
 import QnaSearch from '../components/qna/QnaSearch'
 import QnaTab from '../components/qna/QnaTab'
 import QnaFilterModal from '../components/qna/QnaFilterModal'
-import thumbnailImg from '../assets/images/thumbnail.png'
 import QnaCard from '../components/qna/QnaCard'
+import { transformQnaData } from '../utils/transformQnaData'
+import { mockQnaListResponse } from '../components/Mocks/MockQnaListResponse'
+import type { CategoryFilter } from '../types/qnaFilters.types'
 
 const QnaListPage: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState('전체보기')
   const [query, setQuery] = useState('')
   const [sortOrder, setSortOrder] = useState<'최신순' | '오래된순'>('최신순')
   const [isFilterOpen, setIsFilterOpen] = useState(false)
-  const [filters, setFilters] = useState({
-    category1: '대분류',
-    category2: '중분류',
-    category3: '소분류',
+  const [filters, setFilters] = useState<CategoryFilter>({
+    main: '대분류',
+    sub: '중분류',
+    detail: '소분류',
   })
 
-  const handleSortChange = (order: '최신순' | '오래된순') => {
-    setSortOrder(order)
-  }
+  const transformedQuestions = transformQnaData(mockQnaListResponse.results)
 
-  const handleFilterClick = () => {
-    setIsFilterOpen(true)
-  }
-
-  const closeFilterModal = () => {
-    setIsFilterOpen(false)
-  }
-
-  const imageUrls = [thumbnailImg]
-
-  const dummyQuestions = Array.from({ length: 10 }, (_, i) => {
-    const hasThumbnail = Math.random() < 0.5
-    const randomImageUrl =
-      imageUrls[Math.floor(Math.random() * imageUrls.length)]
-
-    return {
-      id: i + 1,
-      title: '오류가 발생했다고 뜹니다.',
-      content:
-        '&lt;/&gt; 실행 결과 오류가 발생했어요.&nbsp;AI 코드리뷰로 왜 오류가 발생했는지 확인해 보세요! File "main.py", line 2 코드를 작성하세요 ^',
-      category: i % 2 === 0 ? '프론트엔드' : '백엔드',
-      subCategory: i % 3 === 0 ? '프로그래밍 언어' : '웹 프레임워크',
-      language: i % 2 === 0 ? 'Python' : 'JavaScript',
-      answerCount: i % 3 === 0 ? 1 : 0,
-      viewCount: 60 + i * 5,
-      nickname: '김태산',
-      time: `${Math.floor(Math.random() * 5) + 1}시간 전`,
-      thumbnail: hasThumbnail ? randomImageUrl : undefined,
-    }
-  })
-
-  const filteredQuestions = dummyQuestions.filter((q) => {
+  const filteredQuestions = transformedQuestions.filter((q) => {
     const lowerQuery = query.toLowerCase()
     const matchQuery =
       q.title.toLowerCase().includes(lowerQuery) ||
       q.content.toLowerCase().includes(lowerQuery)
 
     const matchCategory =
-      (filters.category1 === '대분류' || q.category === filters.category1) &&
-      (filters.category2 === '중분류' || q.subCategory === filters.category2) &&
-      (filters.category3 === '소분류' || q.language === filters.category3)
+      (filters.main === '대분류' || q.category === filters.main) &&
+      (filters.sub === '중분류' || q.subCategory === filters.sub) &&
+      (filters.detail === '소분류' || q.language === filters.detail)
 
     return matchQuery && matchCategory
   })
@@ -80,8 +48,8 @@ const QnaListPage: React.FC = () => {
             selectedTab={selectedTab}
             onSelectTab={setSelectedTab}
             sortOrder={sortOrder}
-            onSortChange={handleSortChange}
-            onClickFilter={handleFilterClick}
+            onSortChange={setSortOrder}
+            onClickFilter={() => setIsFilterOpen(true)}
           />
         </div>
 
@@ -94,8 +62,8 @@ const QnaListPage: React.FC = () => {
 
       {isFilterOpen && (
         <QnaFilterModal
-          onClose={closeFilterModal}
-          onApply={(newFilters) => setFilters(newFilters)}
+          onClose={() => setIsFilterOpen(false)}
+          onApply={setFilters}
         />
       )}
     </>

--- a/src/types/qnaCard.types.ts
+++ b/src/types/qnaCard.types.ts
@@ -1,0 +1,13 @@
+export type QuestionCard = {
+  id: number
+  title: string
+  content: string
+  category: string
+  subCategory: string
+  language: string
+  answerCount: number
+  viewCount: number
+  nickname: string
+  time: string
+  thumbnail?: string
+}

--- a/src/types/qnaFilters.types.ts
+++ b/src/types/qnaFilters.types.ts
@@ -1,0 +1,5 @@
+export type CategoryFilter = {
+  main: string
+  sub: string
+  detail: string
+}

--- a/src/utils/highlightText.tsx
+++ b/src/utils/highlightText.tsx
@@ -1,0 +1,21 @@
+export const highlightText = (
+  text: string,
+  keyword: string
+): React.ReactNode => {
+  if (!keyword) return text
+
+  const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regex = new RegExp(`(${escapedKeyword})`, 'gi')
+
+  const parts = text.split(regex)
+
+  return parts.map((part, idx) =>
+    regex.test(part) ? (
+      <span key={idx} className="text-[#6201E0] font-semibold">
+        {part}
+      </span>
+    ) : (
+      <span key={idx}>{part}</span>
+    )
+  )
+}

--- a/src/utils/transformQnaData.ts
+++ b/src/utils/transformQnaData.ts
@@ -1,0 +1,22 @@
+// utils/transformQnaData.ts
+export const transformQnaData = (results: any[]) => {
+  const formatRelativeTime = (isoTime: string) => {
+    const diffMs = new Date().getTime() - new Date(isoTime).getTime()
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
+    return diffHours < 1 ? '방금 전' : `${diffHours}시간 전`
+  }
+
+  return results.map((item) => ({
+    id: item.id,
+    title: item.title,
+    content: item.content,
+    category: item.category.depth_1,
+    subCategory: item.category.depth_2,
+    language: item.category.depth_3,
+    answerCount: item.answer_count,
+    viewCount: item.view_count,
+    nickname: item.author.nickname,
+    time: formatRelativeTime(item.created_at),
+    thumbnail: item.thumbnail,
+  }))
+}


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: 
  - #9
  - #10

## 🔄 변경 사항

<!-- 해당되는 항목만 남기고 삭제하세요 -->

- [x] 리팩토링
- [x] 스타일 수정
- [x] 기타 (환경설정)

## ✔️ 변경 사항 상세 설명

- SingleDropdown.tsx -> QnaFilterModal.tsx에 적용

- 변경된 파일: `QnaFilterModal.tsx`
- 주요 구현/수정 내용:
   -  카테고리 관련 변수명을 category1, category2, category3에서 main, sub, detail로 변경
   -  카테고리 목업 데이터를 대→중→소 구조를 반영한 계층적 객체 형태로 재구성
   - DEFAULT_CATEGORY를 상수로 분리하여 초기값을 관리
   - 불필요하거나 중복된 로직은 제거하고, 네이밍을 목적과 일치하도록 개선
   - 카테고리 관련 데이터와 로직은 하나의 객체 기반으로 통합 관리

- 변경된 파일: `QnaCard.tsx`
- 주요 구현/수정 내용:
   - 질문 카드에서 사용하는 Card 타입을 types 폴더로 분리
   - 검색어 하이라이트 기능(highlightText)은 utils 폴더로 이동
   - 질문 카드 전체를 로 감싸고, to={/qna/${question.id}} 형태로 라우팅을 연결
   - 마진(mb-) 관련 누락된 스타일을 복구 및 정리

- 변경된 파일: `QnaListPage.tsx`
- 주요 구현/수정 내용:
   - 더미(mock) 데이터는 별도의 파일로 분리
   - 상태(state) 정의 방식에서 일부는 분리하고 일부는 객체로 묶는 등 혼용되던 방식을 일관되게 통일

