### PR TITLE
feat(#12): markdowneditor수정, 질문등록페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import SignUpPage from './pages/SignUpPage'
 import SignUpFormPage from './pages/SignUpFormPage'
 import ChangePasswordPage from '../src/pages/ChangePasswordPage'
 import QnaCreatePage from './pages/QnaCreatePage'
+import ErrorPage from './pages/ErrorPage'
 
 function App() {
   return (
@@ -26,6 +27,7 @@ function App() {
           <Route path="signupform" element={<SignUpFormPage />} />
           <Route path="changePassword" element={<ChangePasswordPage />} />
           <Route path="qna/create" element={<QnaCreatePage />} />
+          <Route path="*" element={<ErrorPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import QnaListPage from './pages/QnaListPage'
 import SignUpPage from './pages/SignUpPage'
 import SignUpFormPage from './pages/SignUpFormPage'
 import ChangePasswordPage from '../src/pages/ChangePasswordPage'
+import QnaCreatePage from './pages/QnaCreatePage'
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
           <Route path="mypage/edit" element={<MypageEdit />} />
           <Route path="signupform" element={<SignUpFormPage />} />
           <Route path="changePassword" element={<ChangePasswordPage />} />
+          <Route path="qna/create" element={<QnaCreatePage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/Mocks/MockCategories.ts
+++ b/src/components/Mocks/MockCategories.ts
@@ -1,0 +1,20 @@
+// src/mocks/MockCategories.ts
+
+export interface Category {
+  id: number
+  name: string
+  category_type: 'major' | 'middle' | 'minor'
+  parent_id?: number
+}
+
+export const mockCategories: Category[] = [
+  { id: 1, name: '웹개발', category_type: 'major' },
+  { id: 2, name: '프로그래밍 언어', category_type: 'major' },
+  { id: 10, name: '프론트엔드', category_type: 'middle', parent_id: 1 },
+  { id: 11, name: '백엔드', category_type: 'middle', parent_id: 1 },
+  { id: 12, name: 'Python', category_type: 'middle', parent_id: 2 },
+  { id: 100, name: 'React', category_type: 'minor', parent_id: 10 },
+  { id: 101, name: 'Vue', category_type: 'minor', parent_id: 10 },
+  { id: 110, name: 'Django', category_type: 'minor', parent_id: 11 },
+  { id: 120, name: '기본 문법', category_type: 'minor', parent_id: 12 },
+]

--- a/src/components/Mocks/MockCategories.ts
+++ b/src/components/Mocks/MockCategories.ts
@@ -1,20 +1,115 @@
-// src/mocks/MockCategories.ts
+// src/Mocks/MockCategories.ts
 
 export interface Category {
   id: number
   name: string
-  category_type: 'major' | 'middle' | 'minor'
-  parent_id?: number
+  type: '대' | '중' | '소'
+  child_categories: Category[]
+  parent_category: string | null
 }
-
 export const mockCategories: Category[] = [
-  { id: 1, name: '웹개발', category_type: 'major' },
-  { id: 2, name: '프로그래밍 언어', category_type: 'major' },
-  { id: 10, name: '프론트엔드', category_type: 'middle', parent_id: 1 },
-  { id: 11, name: '백엔드', category_type: 'middle', parent_id: 1 },
-  { id: 12, name: 'Python', category_type: 'middle', parent_id: 2 },
-  { id: 100, name: 'React', category_type: 'minor', parent_id: 10 },
-  { id: 101, name: 'Vue', category_type: 'minor', parent_id: 10 },
-  { id: 110, name: 'Django', category_type: 'minor', parent_id: 11 },
-  { id: 120, name: '기본 문법', category_type: 'minor', parent_id: 12 },
+  {
+    id: 1,
+    name: '웹개발',
+    type: '대',
+    parent_category: null,
+    child_categories: [
+      {
+        id: 10,
+        name: '프론트엔드',
+        type: '중',
+        parent_category: '웹개발',
+        child_categories: [
+          {
+            id: 100,
+            name: 'React',
+            type: '소',
+            parent_category: '프론트엔드',
+            child_categories: [],
+          },
+          {
+            id: 101,
+            name: 'Vue',
+            type: '소',
+            parent_category: '프론트엔드',
+            child_categories: [],
+          },
+        ],
+      },
+      {
+        id: 11,
+        name: '백엔드',
+        type: '중',
+        parent_category: '웹개발',
+        child_categories: [
+          {
+            id: 110,
+            name: 'Django',
+            type: '소',
+            parent_category: '백엔드',
+            child_categories: [],
+          },
+          {
+            id: 111,
+            name: 'Express',
+            type: '소',
+            parent_category: '백엔드',
+            child_categories: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: '프로그래밍 언어',
+    type: '대',
+    parent_category: null,
+    child_categories: [
+      {
+        id: 12,
+        name: 'Python',
+        type: '중',
+        parent_category: '프로그래밍 언어',
+        child_categories: [
+          {
+            id: 120,
+            name: '기본 문법',
+            type: '소',
+            parent_category: 'Python',
+            child_categories: [],
+          },
+          {
+            id: 121,
+            name: 'Django 심화',
+            type: '소',
+            parent_category: 'Python',
+            child_categories: [],
+          },
+        ],
+      },
+      {
+        id: 13,
+        name: 'JavaScript',
+        type: '중',
+        parent_category: '프로그래밍 언어',
+        child_categories: [
+          {
+            id: 130,
+            name: 'ES6',
+            type: '소',
+            parent_category: 'JavaScript',
+            child_categories: [],
+          },
+          {
+            id: 131,
+            name: 'Node.js',
+            type: '소',
+            parent_category: 'JavaScript',
+            child_categories: [],
+          },
+        ],
+      },
+    ],
+  },
 ]

--- a/src/components/common/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor/MarkdownEditor.tsx
@@ -349,7 +349,7 @@ const MarkdownEditor = ({
   return (
     <div className={className} style={{ width }}>
       <div
-        className={`border rounded-lg overflow-hidden relative ${
+        className={`border border-gray-250 rounded-lg overflow-hidden relative ${
           isDragOver ? 'border-blue-500 border-2 bg-blue-50' : ''
         }`}
         {...dragHandlers}

--- a/src/components/common/MarkdownEditor/Toolbar/Toolbar.tsx
+++ b/src/components/common/MarkdownEditor/Toolbar/Toolbar.tsx
@@ -89,7 +89,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
   const Divider = () => <div className="w-px h-6 bg-gray-300 mx-2" />
 
   return (
-    <div className="bg-gray-50 border-b p-2 flex items-center gap-2 flex-wrap">
+    <div className="bg-gray-50 border border-gray-250 p-2 flex items-center gap-2 flex-wrap">
       {headingButtons.map((button, index) => (
         <ToolbarButton
           key={`heading-${index}`}

--- a/src/components/common/MarkdownEditor/Toolbar/ToolbarButton.tsx
+++ b/src/components/common/MarkdownEditor/Toolbar/ToolbarButton.tsx
@@ -19,7 +19,7 @@ const ToolbarButton: React.FC<ToolbarButtonProps> = ({
   <button
     onClick={onClick}
     title={title}
-    className={`cursor-pointer p-2 rounded transition-colors flex items-center gap-1 ${
+    className={`p-2 rounded transition-colors flex items-center gap-1 ${
       isActive ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200 text-gray-600'
     }`}
   >

--- a/src/components/qna/QnaCategorySelect.tsx
+++ b/src/components/qna/QnaCategorySelect.tsx
@@ -1,78 +1,88 @@
-// src/components/qna/QnaCategorySelect.tsx
-import SingleDropdown from '../common/SingleDropdown'
-import { mockCategories } from '../../components/Mocks/MockCategories'
+import SingleDropdown from '../../components/common/SingleDropdown'
+import { mockCategories } from '../Mocks/MockCategories'
+import { useState } from 'react'
 
-interface Props {
-  majorId: number | null
-  setMajorId: (id: number | null) => void
-  middleId: number | null
-  setMiddleId: (id: number | null) => void
-  minorId: number | null
-  setMinorId: (id: number | null) => void
+interface SelectedCategories {
+  major: string | null
+  middle: string | null
+  minor: string | null
 }
 
-export default function QnaCategorySelect({
-  majorId,
-  setMajorId,
-  middleId,
-  setMiddleId,
-  minorId,
-  setMinorId,
-}: Props) {
-  // 대분류, 중분류, 소분류 옵션 추출 (타입 추론 O)
-  const majorOptions = mockCategories.filter(
-    (cat) => cat.category_type === 'major'
-  )
-  const middleOptions = mockCategories.filter(
-    (cat) => cat.category_type === 'middle' && cat.parent_id === majorId
-  )
-  const minorOptions = mockCategories.filter(
-    (cat) => cat.category_type === 'minor' && cat.parent_id === middleId
-  )
+export default function QnaCategorySelect() {
+  const [selectedCategories, setSelectedCategories] =
+    useState<SelectedCategories>({
+      major: null,
+      middle: null,
+      minor: null,
+    })
+
+  // 대분류 옵션
+  const majorOptions = mockCategories.map((item) => item.name)
+
+  // 중분류 옵션 (추가!)
+  let middleOptions: string[] = []
+  if (selectedCategories.major) {
+    const selectedMajor = mockCategories.find(
+      (item) => item.name === selectedCategories.major
+    )
+    if (selectedMajor) {
+      middleOptions = selectedMajor.child_categories.map((child) => child.name)
+    }
+  }
+
+  // 소분류 옵션 (추가!)
+  let minorOptions: string[] = []
+  if (selectedCategories.middle) {
+    const selectedMajor = mockCategories.find(
+      (item) => item.name === selectedCategories.major
+    )
+    if (selectedMajor) {
+      const selectedMiddle = selectedMajor.child_categories.find(
+        (child) => child.name === selectedCategories.middle
+      )
+      if (selectedMiddle) {
+        minorOptions = selectedMiddle.child_categories.map(
+          (child) => child.name
+        )
+      }
+    }
+  }
 
   return (
     <div className="grid grid-cols-3 gap-4 mb-6">
-      {/* 대분류 */}
       <SingleDropdown
-        options={['대분류 선택', ...majorOptions.map((cat) => cat.name)]}
-        selected={
-          majorOptions.find((cat) => cat.id === majorId)?.name || '대분류 선택'
-        }
-        onChange={(value) => {
-          const found = majorOptions.find((cat) => cat.name === value)
-          setMajorId(found?.id ?? null)
-          setMiddleId(null)
-          setMinorId(null)
-        }}
+        options={majorOptions}
         placeholder="대분류 선택"
-      />
-      {/* 중분류 */}
-      <SingleDropdown
-        options={['중분류 선택', ...middleOptions.map((cat) => cat.name)]}
-        selected={
-          middleOptions.find((cat) => cat.id === middleId)?.name ||
-          '중분류 선택'
-        }
-        onChange={(value) => {
-          const found = middleOptions.find((cat) => cat.name === value)
-          setMiddleId(found?.id ?? null)
-          setMinorId(null)
+        onChange={(selected) => {
+          setSelectedCategories({
+            major: selected,
+            middle: null,
+            minor: null,
+          })
         }}
+      />
+      <SingleDropdown
+        options={middleOptions}
         placeholder="중분류 선택"
-        disabled={!majorId}
-      />
-      {/* 소분류 */}
-      <SingleDropdown
-        options={['소분류 선택', ...minorOptions.map((cat) => cat.name)]}
-        selected={
-          minorOptions.find((cat) => cat.id === minorId)?.name || '소분류 선택'
-        }
-        onChange={(value) => {
-          const found = minorOptions.find((cat) => cat.name === value)
-          setMinorId(found?.id ?? null)
+        onChange={(selected) => {
+          setSelectedCategories((prevCategories) => ({
+            ...prevCategories,
+            middle: selected,
+            minor: null,
+          }))
         }}
+        disabled={!selectedCategories.major}
+      />
+      <SingleDropdown
+        options={minorOptions}
         placeholder="소분류 선택"
-        disabled={!middleId}
+        onChange={(selected) => {
+          setSelectedCategories((prevCategories) => ({
+            ...prevCategories,
+            minor: selected,
+          }))
+        }}
+        disabled={!selectedCategories.middle}
       />
     </div>
   )

--- a/src/components/qna/QnaCategorySelect.tsx
+++ b/src/components/qna/QnaCategorySelect.tsx
@@ -1,0 +1,79 @@
+// src/components/qna/QnaCategorySelect.tsx
+import SingleDropdown from '../common/SingleDropdown'
+import { mockCategories } from '../../components/Mocks/MockCategories'
+
+interface Props {
+  majorId: number | null
+  setMajorId: (id: number | null) => void
+  middleId: number | null
+  setMiddleId: (id: number | null) => void
+  minorId: number | null
+  setMinorId: (id: number | null) => void
+}
+
+export default function QnaCategorySelect({
+  majorId,
+  setMajorId,
+  middleId,
+  setMiddleId,
+  minorId,
+  setMinorId,
+}: Props) {
+  // 대분류, 중분류, 소분류 옵션 추출 (타입 추론 O)
+  const majorOptions = mockCategories.filter(
+    (cat) => cat.category_type === 'major'
+  )
+  const middleOptions = mockCategories.filter(
+    (cat) => cat.category_type === 'middle' && cat.parent_id === majorId
+  )
+  const minorOptions = mockCategories.filter(
+    (cat) => cat.category_type === 'minor' && cat.parent_id === middleId
+  )
+
+  return (
+    <div className="grid grid-cols-3 gap-4 mb-6">
+      {/* 대분류 */}
+      <SingleDropdown
+        options={['대분류 선택', ...majorOptions.map((cat) => cat.name)]}
+        selected={
+          majorOptions.find((cat) => cat.id === majorId)?.name || '대분류 선택'
+        }
+        onChange={(value) => {
+          const found = majorOptions.find((cat) => cat.name === value)
+          setMajorId(found?.id ?? null)
+          setMiddleId(null)
+          setMinorId(null)
+        }}
+        placeholder="대분류 선택"
+      />
+      {/* 중분류 */}
+      <SingleDropdown
+        options={['중분류 선택', ...middleOptions.map((cat) => cat.name)]}
+        selected={
+          middleOptions.find((cat) => cat.id === middleId)?.name ||
+          '중분류 선택'
+        }
+        onChange={(value) => {
+          const found = middleOptions.find((cat) => cat.name === value)
+          setMiddleId(found?.id ?? null)
+          setMinorId(null)
+        }}
+        placeholder="중분류 선택"
+        disabled={!majorId}
+      />
+      {/* 소분류 */}
+      <SingleDropdown
+        options={['소분류 선택', ...minorOptions.map((cat) => cat.name)]}
+        selected={
+          minorOptions.find((cat) => cat.id === minorId)?.name || '소분류 선택'
+        }
+        onChange={(value) => {
+          const found = minorOptions.find((cat) => cat.name === value)
+          setMinorId(found?.id ?? null)
+        }}
+        placeholder="소분류 선택"
+        disabled={!middleId}
+      />
+    </div>
+  )
+}

--- a/src/components/qna/QnaTitleInput.tsx
+++ b/src/components/qna/QnaTitleInput.tsx
@@ -12,7 +12,7 @@ export default function QnaTitleInput({ value, onChange }: Props) {
       type="text"
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      placeholder="제목을 입력해 주세요 (최대 50자)"
+      placeholder="제목을 입력해 주세요"
       maxLength={50}
       className={cn(
         'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors',

--- a/src/components/qna/QnaTitleInput.tsx
+++ b/src/components/qna/QnaTitleInput.tsx
@@ -1,0 +1,24 @@
+// src/components/qna/QnaTitleInput.tsx
+import { cn } from '../../utils/cn'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+}
+
+export default function QnaTitleInput({ value, onChange }: Props) {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="제목을 입력해 주세요 (최대 50자)"
+      maxLength={50}
+      className={cn(
+        'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors',
+        'text-base bg-primary-50 border-gray-disabled text-gray',
+        'focus:border-primary focus:bg-gray-50'
+      )}
+    />
+  )
+}

--- a/src/pages/QnaCreatePage.tsx
+++ b/src/pages/QnaCreatePage.tsx
@@ -1,96 +1,28 @@
-// src/pages/QnaCreatePage.tsx
-import { useState } from 'react'
 import QnaCategorySelect from '../components/qna/QnaCategorySelect'
-import QnaTitleInput from '../components/qna/QnaTitleInput'
 import MarkdownEditor from '../components/common/MarkdownEditor'
+import QnaTitleInput from '../components/qna/QnaTitleInput'
 import Button from '../components/common/Button'
-import Modal from '../components/common/Modal'
 
 export default function QnaCreatePage() {
-  const [majorId, setMajorId] = useState<number | null>(null)
-  const [middleId, setMiddleId] = useState<number | null>(null)
-  const [minorId, setMinorId] = useState<number | null>(null)
-  const [title, setTitle] = useState('')
-  const [content, setContent] = useState('')
-  const [modalOpen, setModalOpen] = useState(false)
-  const [modalMsg, setModalMsg] = useState('')
-  const [loading, setLoading] = useState(false)
-
-  const handleSubmit = () => {
-    if (!title.trim() || !content.trim() || !minorId) {
-      setModalMsg('제목, 내용, 소분류를 모두 입력해주세요!')
-      setModalOpen(true)
-      return
-    }
-    setLoading(true)
-    setTimeout(() => {
-      // 실제로는 여기에 API 호출을 넣으면 됨
-      // (개발 중에는 아래 log를 살려도 되고, 배포 시에는 주석처리/삭제)
-      // eslint-disable-next-line no-console
-      console.log('질문 등록 데이터:', {
-        title,
-        content,
-        category_id: minorId,
-      })
-      setLoading(false)
-      setModalMsg('질문이 정상적으로 등록되었습니다!')
-      setModalOpen(true)
-      setTitle('')
-      setContent('')
-      setMajorId(null)
-      setMiddleId(null)
-      setMinorId(null)
-    }, 800)
-  }
-
   return (
     <div className="min-h-screen">
       <div className="mx-auto px-4 py-8 w-[944px]">
         <h1 className="text-2xl font-bold text-gray mb-2">질문 작성하기</h1>
         <hr className="border-gray-250 mb-8" />
-        <div className="bg-white rounded-lg p-6 mb-6 border border-gray-250">
-          <QnaCategorySelect
-            majorId={majorId}
-            setMajorId={setMajorId}
-            middleId={middleId}
-            setMiddleId={setMiddleId}
-            minorId={minorId}
-            setMinorId={setMinorId}
-          />
-          <QnaTitleInput value={title} onChange={setTitle} />
+
+        <div className="rounded-lg p-6 mb-6 border border-gray-250">
+          <QnaCategorySelect />
+          <QnaTitleInput />
         </div>
+
         <div className="mb-6">
-          <MarkdownEditor
-            value={content}
-            onChange={setContent}
-            placeholder="내용을 입력해 주세요"
-            height="500px"
-            width="100%"
-            showPreview
-          />
+          <MarkdownEditor placeholder="내용을 입력해 주세요." showPreview />
         </div>
+
         <div className="flex justify-end">
-          <Button
-            variant="fill"
-            onClick={handleSubmit}
-            disabled={loading || !title.trim() || !content.trim() || !minorId}
-          >
-            {loading ? '등록 중...' : '등록하기'}
-          </Button>
+          <Button />
         </div>
       </div>
-      <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)}>
-        <div className="text-center py-6 px-4">
-          <h3 className="text-lg font-semibold text-gray mb-4">{modalMsg}</h3>
-          <Button
-            variant="fill"
-            onClick={() => setModalOpen(false)}
-            className="px-8"
-          >
-            확인
-          </Button>
-        </div>
-      </Modal>
     </div>
   )
 }

--- a/src/pages/QnaCreatePage.tsx
+++ b/src/pages/QnaCreatePage.tsx
@@ -1,176 +1,64 @@
-import React, { useState } from 'react'
-import { cn } from '../utils/cn'
+// src/pages/QnaCreatePage.tsx
+import { useState } from 'react'
+import QnaCategorySelect from '../components/qna/QnaCategorySelect'
+import QnaTitleInput from '../components/qna/QnaTitleInput'
+import MarkdownEditor from '../components/common/MarkdownEditor'
 import Button from '../components/common/Button'
 import Modal from '../components/common/Modal'
-import MarkdownEditor from '../components/common/MarkdownEditor'
-import SingleDropdown from '../components/common/SingleDropdown'
 
-interface Category {
-  id: number
-  name: string
-  parent_id?: number
-}
-
-interface TitleInputProps {
-  value: string
-  onChange: (value: string) => void
-  placeholder: string
-}
-
-const TitleInput: React.FC<TitleInputProps> = ({
-  value,
-  onChange,
-  placeholder,
-}) => (
-  <input
-    type="text"
-    value={value}
-    onChange={(e) => onChange(e.target.value)}
-    placeholder={placeholder}
-    className={cn(
-      'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors',
-      'text-base bg-primary-50 border-gray-disabled text-gray',
-      'focus:border-primary focus:bg-gray-50'
-    )}
-    maxLength={50}
-  />
-)
-
-const QnaCreatePage: React.FC = () => {
+export default function QnaCreatePage() {
+  const [majorId, setMajorId] = useState<number | null>(null)
+  const [middleId, setMiddleId] = useState<number | null>(null)
+  const [minorId, setMinorId] = useState<number | null>(null)
   const [title, setTitle] = useState('')
-  const [category1, setCategory1] = useState('')
-  const [category2, setCategory2] = useState('')
-  const [category3, setCategory3] = useState('')
   const [content, setContent] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
-  const [showModal, setShowModal] = useState(false)
-  const [modalMessage, setModalMessage] = useState('')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [modalMsg, setModalMsg] = useState('')
+  const [loading, setLoading] = useState(false)
 
-  const categoryOptions = {
-    category1: [
-      { id: 0, name: '카테고리 선택' },
-      { id: 1, name: '개발' },
-      { id: 2, name: '디자인' },
-      { id: 3, name: '마케팅' },
-      { id: 4, name: '기획' },
-    ],
-    category2: [
-      { id: 0, name: '상세 카테고리' },
-      { id: 11, name: 'Frontend', parent_id: 1 },
-      { id: 12, name: 'Backend', parent_id: 1 },
-      { id: 13, name: 'DevOps', parent_id: 1 },
-      { id: 14, name: '모바일', parent_id: 1 },
-    ],
-    category3: [
-      { id: 0, name: '세부 카테고리' },
-      { id: 111, name: 'React', parent_id: 11 },
-      { id: 112, name: 'Vue', parent_id: 11 },
-      { id: 113, name: 'Angular', parent_id: 11 },
-      { id: 121, name: 'Django', parent_id: 12 },
-      { id: 122, name: 'Node.js', parent_id: 12 },
-    ],
-  }
-
-  const handleSubmit = async () => {
-    if (!title.trim() || !content.trim()) {
-      setModalMessage('질문 제목과 내용을 입력해주세요')
-      setShowModal(true)
+  const handleSubmit = () => {
+    if (!title.trim() || !content.trim() || !minorId) {
+      setModalMsg('제목, 내용, 소분류를 모두 입력해주세요!')
+      setModalOpen(true)
       return
     }
-
-    const selectedCategory = categoryOptions.category3.find(
-      (cat) => cat.name === category3
-    )
-    if (!selectedCategory || selectedCategory.id === 0) {
-      setModalMessage('유효한 소분류 카테고리를 선택해주세요.')
-      setShowModal(true)
-      return
-    }
-
-    setIsLoading(true)
-
-    // UI 시뮬레이션을 위한 지연
+    setLoading(true)
     setTimeout(() => {
+      // 실제로는 여기에 API 호출을 넣으면 됨
+      // (개발 중에는 아래 log를 살려도 되고, 배포 시에는 주석처리/삭제)
+      // eslint-disable-next-line no-console
+      console.log('질문 등록 데이터:', {
+        title,
+        content,
+        category_id: minorId,
+      })
+      setLoading(false)
+      setModalMsg('질문이 정상적으로 등록되었습니다!')
+      setModalOpen(true)
       setTitle('')
       setContent('')
-      setCategory1('')
-      setCategory2('')
-      setCategory3('')
-      setModalMessage('질문이 등록되었습니다!')
-      setShowModal(true)
-      setIsLoading(false)
-    }, 1000)
+      setMajorId(null)
+      setMiddleId(null)
+      setMinorId(null)
+    }, 800)
   }
-
-  const getFilteredCategories = (level: 'category2' | 'category3') => {
-    const parentLevel = level === 'category2' ? 'category1' : 'category2'
-    const parentValue = level === 'category2' ? category1 : category2
-    const defaultCategory = categoryOptions[level][0]
-
-    const selected = (
-      categoryOptions[parentLevel as keyof typeof categoryOptions] as Category[]
-    ).find((cat: Category) => cat.name === parentValue)
-
-    if (!selected || selected.id === 0) return [defaultCategory]
-    return categoryOptions[level].filter(
-      (cat) => cat.id === 0 || cat.parent_id === selected.id
-    )
-  }
-
-  const isButtonDisabled =
-    isLoading ||
-    !category1 ||
-    !category2 ||
-    !category3 ||
-    category1 === '카테고리 선택' ||
-    category2 === '상세 카테고리' ||
-    category3 === '세부 카테고리'
 
   return (
     <div className="min-h-screen">
       <div className="mx-auto px-4 py-8 w-[944px]">
         <h1 className="text-2xl font-bold text-gray mb-2">질문 작성하기</h1>
         <hr className="border-gray-250 mb-8" />
-
         <div className="bg-white rounded-lg p-6 mb-6 border border-gray-250">
-          <div className="grid grid-cols-3 gap-4 mb-6">
-            <SingleDropdown
-              options={categoryOptions.category1.map((cat) => cat.name)}
-              placeholder="대분류 선택"
-              onChange={(value) => {
-                setCategory1(value)
-                setCategory2('')
-                setCategory3('')
-              }}
-            />
-            <SingleDropdown
-              options={getFilteredCategories('category2').map(
-                (cat) => cat.name
-              )}
-              placeholder="중분류 선택"
-              onChange={(value) => {
-                setCategory2(value)
-                setCategory3('')
-              }}
-              disabled={!category1 || category1 === '카테고리 선택'}
-            />
-            <SingleDropdown
-              options={getFilteredCategories('category3').map(
-                (cat) => cat.name
-              )}
-              placeholder="소분류 선택"
-              onChange={setCategory3}
-              disabled={!category2 || category2 === '상세 카테고리'}
-            />
-          </div>
-
-          <TitleInput
-            value={title}
-            onChange={setTitle}
-            placeholder="제목을 입력해 주세요 (최대 50자)"
+          <QnaCategorySelect
+            majorId={majorId}
+            setMajorId={setMajorId}
+            middleId={middleId}
+            setMiddleId={setMiddleId}
+            minorId={minorId}
+            setMinorId={setMinorId}
           />
+          <QnaTitleInput value={title} onChange={setTitle} />
         </div>
-
         <div className="mb-6">
           <MarkdownEditor
             value={content}
@@ -181,26 +69,22 @@ const QnaCreatePage: React.FC = () => {
             showPreview
           />
         </div>
-
         <div className="flex justify-end">
           <Button
             variant="fill"
             onClick={handleSubmit}
-            disabled={isButtonDisabled}
+            disabled={loading || !title.trim() || !content.trim() || !minorId}
           >
-            {isLoading ? '등록 중...' : '등록하기'}
+            {loading ? '등록 중...' : '등록하기'}
           </Button>
         </div>
       </div>
-
-      <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
+      <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)}>
         <div className="text-center py-6 px-4">
-          <h3 className="text-lg font-semibold text-gray mb-4">
-            {modalMessage}
-          </h3>
+          <h3 className="text-lg font-semibold text-gray mb-4">{modalMsg}</h3>
           <Button
             variant="fill"
-            onClick={() => setShowModal(false)}
+            onClick={() => setModalOpen(false)}
             className="px-8"
           >
             확인
@@ -210,5 +94,3 @@ const QnaCreatePage: React.FC = () => {
     </div>
   )
 }
-
-export default QnaCreatePage

--- a/src/pages/QnaCreatePage.tsx
+++ b/src/pages/QnaCreatePage.tsx
@@ -1,18 +1,22 @@
+import { useState } from 'react'
 import QnaCategorySelect from '../components/qna/QnaCategorySelect'
 import MarkdownEditor from '../components/common/MarkdownEditor'
 import QnaTitleInput from '../components/qna/QnaTitleInput'
 import Button from '../components/common/Button'
 
 export default function QnaCreatePage() {
+  const [title, setTitle] = useState('')
   return (
     <div className="min-h-screen">
       <div className="mx-auto px-4 py-8 w-[944px]">
-        <h1 className="text-2xl font-bold text-gray mb-2">질문 작성하기</h1>
+        <h1 className="text-2xl font-bold text-gray mb-3">질문 작성하기</h1>
         <hr className="border-gray-250 mb-8" />
 
         <div className="rounded-lg p-6 mb-6 border border-gray-250">
-          <QnaCategorySelect />
-          <QnaTitleInput />
+          <div className="mb-6">
+            <QnaCategorySelect />
+          </div>
+          <QnaTitleInput value={title} onChange={setTitle} />
         </div>
 
         <div className="mb-6">
@@ -20,7 +24,7 @@ export default function QnaCreatePage() {
         </div>
 
         <div className="flex justify-end">
-          <Button />
+          <Button>등록하기</Button>
         </div>
       </div>
     </div>

--- a/src/pages/QnaCreatePage.tsx
+++ b/src/pages/QnaCreatePage.tsx
@@ -1,0 +1,214 @@
+import React, { useState } from 'react'
+import { cn } from '../utils/cn'
+import Button from '../components/common/Button'
+import Modal from '../components/common/Modal'
+import MarkdownEditor from '../components/common/MarkdownEditor'
+import SingleDropdown from '../components/common/SingleDropdown'
+
+interface Category {
+  id: number
+  name: string
+  parent_id?: number
+}
+
+interface TitleInputProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder: string
+}
+
+const TitleInput: React.FC<TitleInputProps> = ({
+  value,
+  onChange,
+  placeholder,
+}) => (
+  <input
+    type="text"
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    placeholder={placeholder}
+    className={cn(
+      'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors',
+      'text-base bg-primary-50 border-gray-disabled text-gray',
+      'focus:border-primary focus:bg-gray-50'
+    )}
+    maxLength={50}
+  />
+)
+
+const QnaCreatePage: React.FC = () => {
+  const [title, setTitle] = useState('')
+  const [category1, setCategory1] = useState('')
+  const [category2, setCategory2] = useState('')
+  const [category3, setCategory3] = useState('')
+  const [content, setContent] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [showModal, setShowModal] = useState(false)
+  const [modalMessage, setModalMessage] = useState('')
+
+  const categoryOptions = {
+    category1: [
+      { id: 0, name: '카테고리 선택' },
+      { id: 1, name: '개발' },
+      { id: 2, name: '디자인' },
+      { id: 3, name: '마케팅' },
+      { id: 4, name: '기획' },
+    ],
+    category2: [
+      { id: 0, name: '상세 카테고리' },
+      { id: 11, name: 'Frontend', parent_id: 1 },
+      { id: 12, name: 'Backend', parent_id: 1 },
+      { id: 13, name: 'DevOps', parent_id: 1 },
+      { id: 14, name: '모바일', parent_id: 1 },
+    ],
+    category3: [
+      { id: 0, name: '세부 카테고리' },
+      { id: 111, name: 'React', parent_id: 11 },
+      { id: 112, name: 'Vue', parent_id: 11 },
+      { id: 113, name: 'Angular', parent_id: 11 },
+      { id: 121, name: 'Django', parent_id: 12 },
+      { id: 122, name: 'Node.js', parent_id: 12 },
+    ],
+  }
+
+  const handleSubmit = async () => {
+    if (!title.trim() || !content.trim()) {
+      setModalMessage('질문 제목과 내용을 입력해주세요')
+      setShowModal(true)
+      return
+    }
+
+    const selectedCategory = categoryOptions.category3.find(
+      (cat) => cat.name === category3
+    )
+    if (!selectedCategory || selectedCategory.id === 0) {
+      setModalMessage('유효한 소분류 카테고리를 선택해주세요.')
+      setShowModal(true)
+      return
+    }
+
+    setIsLoading(true)
+
+    // UI 시뮬레이션을 위한 지연
+    setTimeout(() => {
+      setTitle('')
+      setContent('')
+      setCategory1('')
+      setCategory2('')
+      setCategory3('')
+      setModalMessage('질문이 등록되었습니다!')
+      setShowModal(true)
+      setIsLoading(false)
+    }, 1000)
+  }
+
+  const getFilteredCategories = (level: 'category2' | 'category3') => {
+    const parentLevel = level === 'category2' ? 'category1' : 'category2'
+    const parentValue = level === 'category2' ? category1 : category2
+    const defaultCategory = categoryOptions[level][0]
+
+    const selected = (
+      categoryOptions[parentLevel as keyof typeof categoryOptions] as Category[]
+    ).find((cat: Category) => cat.name === parentValue)
+
+    if (!selected || selected.id === 0) return [defaultCategory]
+    return categoryOptions[level].filter(
+      (cat) => cat.id === 0 || cat.parent_id === selected.id
+    )
+  }
+
+  const isButtonDisabled =
+    isLoading ||
+    !category1 ||
+    !category2 ||
+    !category3 ||
+    category1 === '카테고리 선택' ||
+    category2 === '상세 카테고리' ||
+    category3 === '세부 카테고리'
+
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto px-4 py-8 w-[944px]">
+        <h1 className="text-2xl font-bold text-gray mb-2">질문 작성하기</h1>
+        <hr className="border-gray-250 mb-8" />
+
+        <div className="bg-white rounded-lg p-6 mb-6 border border-gray-250">
+          <div className="grid grid-cols-3 gap-4 mb-6">
+            <SingleDropdown
+              options={categoryOptions.category1.map((cat) => cat.name)}
+              placeholder="대분류 선택"
+              onChange={(value) => {
+                setCategory1(value)
+                setCategory2('')
+                setCategory3('')
+              }}
+            />
+            <SingleDropdown
+              options={getFilteredCategories('category2').map(
+                (cat) => cat.name
+              )}
+              placeholder="중분류 선택"
+              onChange={(value) => {
+                setCategory2(value)
+                setCategory3('')
+              }}
+              disabled={!category1 || category1 === '카테고리 선택'}
+            />
+            <SingleDropdown
+              options={getFilteredCategories('category3').map(
+                (cat) => cat.name
+              )}
+              placeholder="소분류 선택"
+              onChange={setCategory3}
+              disabled={!category2 || category2 === '상세 카테고리'}
+            />
+          </div>
+
+          <TitleInput
+            value={title}
+            onChange={setTitle}
+            placeholder="제목을 입력해 주세요 (최대 50자)"
+          />
+        </div>
+
+        <div className="mb-6">
+          <MarkdownEditor
+            value={content}
+            onChange={setContent}
+            placeholder="내용을 입력해 주세요"
+            height="500px"
+            width="100%"
+            showPreview
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            variant="fill"
+            onClick={handleSubmit}
+            disabled={isButtonDisabled}
+          >
+            {isLoading ? '등록 중...' : '등록하기'}
+          </Button>
+        </div>
+      </div>
+
+      <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
+        <div className="text-center py-6 px-4">
+          <h3 className="text-lg font-semibold text-gray mb-4">
+            {modalMessage}
+          </h3>
+          <Button
+            variant="fill"
+            onClick={() => setShowModal(false)}
+            className="px-8"
+          >
+            확인
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  )
+}
+
+export default QnaCreatePage


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #12

---

## 🔄 변경 사항

- [x] 기능 추가
- [ ] 문서화
- [ ] 스타일 수정

---

## ✔️ 변경 사항 상세 설명

- **Qna 질문 등록 페이지(QnaCreatePage) 신규 구현**
  - src/pages/QnaCreatePage.tsx 신규 작성 및 라우터 연결(App.tsx)
  - 카테고리 3단(대/중/소분류) 드롭다운 분리(QnaCategorySelect 컴포넌트)
    - mockCategories 데이터 기반으로 major/middle/minor 상태 관리
  - 제목 입력, 마크다운 에디터 컴포넌트 분리(QnaTitleInput, MarkdownEditor)
  - 입력값 검증(소분류 미선택/제목/본문 미입력 시 등록 불가)
  - 등록 버튼 클릭 시, 입력 데이터 콘솔 출력(서버 API 연동 전 임시 처리)
  - Modal 컴포넌트로 안내 메시지 처리(성공/오류 알림)
- **목데이터 기반 개발/실험 환경 세팅**
  - mockCategories.ts, MockQnaListResponse.ts 등 목데이터 파일 작성
  - 카테고리 선택 시 ID 기반으로 값 처리(향후 API 연동 대비 구조화)
- **공통 컴포넌트 재사용성 개선**
  - Button, Modal, SingleDropdown 등 공통 컴포넌트로 일관성 유지
- **코드 스타일/구조화**
  - UI/상태/로직 분리(컴포넌트 단위 분리 및 관심사 명확화)
  - 추후 API 연동/실서비스 적용을 고려한 확장성 구조

---

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1512" alt="스크린샷 2025-07-04 오전 3 31 07" src="https://github.com/user-attachments/assets/17069096-3cad-48b0-af0f-95571ca32c40" />
<img width="1512" alt="스크린샷 2025-07-04 오전 3 30 07" src="https://github.com/user-attachments/assets/a84f5ff5-89be-4253-928b-3389e42046a9" />


---

## 📝 문서화


---

## 🔍 리뷰어에게 요청 사항 (선택)

- 카테고리 선택(3단) 및 상태관리 구조에 대한 피드백 요청
- 향후 이미지 업로드/API 연동시 고려해야 할 부분 있으면 코멘트 부탁드립니다

---

## ⚠️ 기타 주의 사항

- 현재는 목데이터/로컬 상태 기반이므로, 백엔드 API 연동시 추가 작업 필요
- 실서비스 적용 전, 이미지 업로드/카테고리/등록 검증 등 백엔드 연동 부분 별도 확인 필요

---