### PR TITLE
feat(#81): 질문 수정 페이지 구현

### DIFF
--- a/src/components/Mocks/MockQuestionDetail.ts
+++ b/src/components/Mocks/MockQuestionDetail.ts
@@ -1,0 +1,14 @@
+// src/mocks/MockQuestionDetail.ts
+export const mockQuestionDetail = {
+  id: 101,
+  title: '질문 제목을 수정합니다',
+  content: '수정된 질문 내용입니다.\n여기에 기존 질문 본문이 들어갑니다.',
+  author: { id: 7, nickname: 'oz_student' },
+  category: { id: 120, name: '기본 문법' }, // minor 카테고리 id!
+  images: [
+    'https://cdn.ozcoding.com/media/questions/101/edit1.jpg',
+    'https://cdn.ozcoding.com/media/questions/101/edit2.jpg',
+  ],
+  created_at: '2025-06-22T14:00:00Z',
+  updated_at: '2025-06-23T08:30:00Z',
+}

--- a/src/pages/QnaUpdatePage.tsx
+++ b/src/pages/QnaUpdatePage.tsx
@@ -1,64 +1,55 @@
-import React, { useState } from 'react'
-import { cn } from '../utils/cn'
+// src/pages/QnaUpdatePage.tsx
+import { useState } from 'react'
+import QnaCategorySelect from '../components/qna/QnaCategorySelect'
+import QnaTitleInput from '../components/qna/QnaTitleInput'
+import MarkdownEditor from '../components/common/MarkdownEditor'
 import Button from '../components/common/Button'
 import Modal from '../components/common/Modal'
-import MarkdownEditor from '../components/common/MarkdownEditor'
-import SingleDropdown from '../components/common/SingleDropdown'
+import { mockQuestionDetail } from '../components/Mocks/MockQuestionDetail'
+import { mockCategories } from '../components/Mocks/MockCategories'
 
-interface QuestionImage {
-  id: number
-  img_url: string
-}
+export default function QnaUpdatePage() {
+  // 초기값 세팅 (카테고리 아이디는 minor만 바로 세팅, 나머지는 mockCategories로 역탐색)
+  const initialMinorId = mockQuestionDetail.category.id
 
-interface QuestionData {
-  title: string
-  content: string
-  category_id: number // 백엔드 기준
-  images?: QuestionImage[] // 기존 첨부 이미지 (미리보기 용)
-}
+  // major, middle 찾기 (minor의 parent -> middle, middle의 parent -> major)
+  const initialMiddleId =
+    mockCategories.find((cat) => cat.id === initialMinorId)?.parent_id ?? null
+  const initialMajorId =
+    mockCategories.find((cat) => cat.id === initialMiddleId)?.parent_id ?? null
 
-interface QnaUpdatePageProps {
-  initialQuestion: QuestionData
-}
+  const [majorId, setMajorId] = useState<number | null>(initialMajorId)
+  const [middleId, setMiddleId] = useState<number | null>(initialMiddleId)
+  const [minorId, setMinorId] = useState<number | null>(initialMinorId)
 
-const categoryOptions = [
-  { id: 0, name: '카테고리 선택' },
-  { id: 1, name: '개발' },
-  { id: 2, name: '디자인' },
-  { id: 3, name: '마케팅' },
-  { id: 4, name: '기획' },
-  // ... 실제 소분류(id)를 써야 함
-]
+  const [title, setTitle] = useState(mockQuestionDetail.title)
+  const [content, setContent] = useState(mockQuestionDetail.content)
 
-const QnaUpdatePage: React.FC<QnaUpdatePageProps> = ({ initialQuestion }) => {
-  const [title, setTitle] = useState(initialQuestion.title)
-  const [content, setContent] = useState(initialQuestion.content)
-  const [categoryId, setCategoryId] = useState(initialQuestion.category_id)
-  const [showModal, setShowModal] = useState(false)
-  const [modalMessage, setModalMessage] = useState('')
-  const [imageFiles, setImageFiles] = useState<File[]>([])
-  const [previewImages, setPreviewImages] = useState<QuestionImage[]>(
-    initialQuestion.images || []
-  )
+  const [modalOpen, setModalOpen] = useState(false)
+  const [modalMsg, setModalMsg] = useState('')
+  const [loading, setLoading] = useState(false)
 
-  // 이미지 파일 첨부 핸들러
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files) return
-    const files = Array.from(e.target.files)
-    setImageFiles(files)
-    // 미리보기 (첨부된 파일들만)
-    // 만약 기존 이미지+새로 첨부한 이미지 둘 다 보여주고 싶으면 previewImages와 병합 가능
-  }
-
-  // 저장 버튼 클릭시 (현재는 디자인만)
-  const handleUpdate = () => {
-    if (!title.trim() || !content.trim() || !categoryId) {
-      setModalMessage('모든 필수값을 입력해주세요.')
-      setShowModal(true)
+  // 저장(수정) 버튼 클릭 핸들러
+  const handleSubmit = () => {
+    if (!title.trim() || !content.trim() || !minorId) {
+      setModalMsg('제목, 내용, 소분류를 모두 입력해주세요!')
+      setModalOpen(true)
       return
     }
-    setModalMessage('질문이 수정되었습니다! (실제 저장은 API 연동 필요)')
-    setShowModal(true)
+
+    setLoading(true)
+    setTimeout(() => {
+      // 실제 API 호출 시 여기서 PATCH 요청
+      // 현재는 콘솔에 출력
+      console.log('질문 수정 데이터:', {
+        title,
+        content,
+        category_id: minorId,
+      })
+      setLoading(false)
+      setModalMsg('질문이 정상적으로 수정되었습니다!')
+      setModalOpen(true)
+    }, 800)
   }
 
   return (
@@ -66,81 +57,18 @@ const QnaUpdatePage: React.FC<QnaUpdatePageProps> = ({ initialQuestion }) => {
       <div className="mx-auto px-4 py-8 w-[944px]">
         <h1 className="text-2xl font-bold text-gray mb-2">질문 수정하기</h1>
         <hr className="border-gray-250 mb-8" />
-
         <div className="bg-white rounded-lg p-6 mb-6 border border-gray-250">
-          {/* 카테고리 드롭다운 (실제 소분류 id 기준) */}
-          <div className="mb-6 w-1/3">
-            <SingleDropdown
-              options={categoryOptions.map((c) => c.name)}
-              selected={
-                categoryOptions.find((c) => c.id === categoryId)?.name || ''
-              }
-              placeholder="카테고리 선택"
-              onChange={(value) => {
-                const cat = categoryOptions.find((c) => c.name === value)
-                setCategoryId(cat ? cat.id : 0)
-              }}
-            />
-          </div>
-
-          {/* 제목 입력 */}
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="제목을 입력해 주세요 (최대 50자)"
-            maxLength={50}
-            className={cn(
-              'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors',
-              'text-base bg-primary-50 border-gray-disabled text-gray',
-              'focus:border-primary focus:bg-gray-50'
-            )}
+          <QnaCategorySelect
+            majorId={majorId}
+            setMajorId={setMajorId}
+            middleId={middleId}
+            setMiddleId={setMiddleId}
+            minorId={minorId}
+            setMinorId={setMinorId}
           />
-
-          {/* 기존 이미지 미리보기 */}
-          {previewImages.length > 0 && (
-            <div className="mt-4 flex gap-3">
-              {previewImages.map((img) => (
-                <img
-                  key={img.id}
-                  src={img.img_url}
-                  alt="첨부 이미지"
-                  className="w-24 h-24 object-cover rounded border border-gray-250"
-                />
-              ))}
-            </div>
-          )}
-
-          {/* 이미지 파일 첨부 */}
-          <div className="mt-4">
-            <label className="block text-sm font-medium text-gray-600 mb-1">
-              이미지 첨부 (최대 5개)
-            </label>
-            <input
-              type="file"
-              multiple
-              accept="image/*"
-              onChange={handleImageChange}
-              className="block w-full text-sm text-gray-400
-                file:mr-4 file:py-2 file:px-4
-                file:rounded-lg file:border-0
-                file:text-sm file:font-semibold
-                file:bg-primary-100 file:text-primary
-                hover:file:bg-primary-50
-              "
-            />
-            {/* 첨부한 이미지 파일명 보여주기 */}
-            {imageFiles.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-600">
-                {imageFiles.map((file, i) => (
-                  <div key={i}>{file.name}</div>
-                ))}
-              </div>
-            )}
-          </div>
+          <QnaTitleInput value={title} onChange={setTitle} />
         </div>
 
-        {/* 내용(마크다운 에디터) */}
         <div className="mb-6">
           <MarkdownEditor
             value={content}
@@ -152,23 +80,23 @@ const QnaUpdatePage: React.FC<QnaUpdatePageProps> = ({ initialQuestion }) => {
           />
         </div>
 
-        {/* 저장 버튼 */}
         <div className="flex justify-end">
-          <Button variant="fill" onClick={handleUpdate}>
+          <Button
+            variant="fill"
+            onClick={handleSubmit}
+            disabled={loading || !title.trim() || !content.trim() || !minorId}
+          >
             저장하기
           </Button>
         </div>
       </div>
 
-      {/* 모달 */}
-      <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
+      <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)}>
         <div className="text-center py-6 px-4">
-          <h3 className="text-lg font-semibold text-gray mb-4">
-            {modalMessage}
-          </h3>
+          <h3 className="text-lg font-semibold text-gray mb-4">{modalMsg}</h3>
           <Button
             variant="fill"
-            onClick={() => setShowModal(false)}
+            onClick={() => setModalOpen(false)}
             className="px-8"
           >
             확인
@@ -178,5 +106,3 @@ const QnaUpdatePage: React.FC<QnaUpdatePageProps> = ({ initialQuestion }) => {
     </div>
   )
 }
-
-export default QnaUpdatePage

--- a/src/pages/QnaUpdatePage.tsx
+++ b/src/pages/QnaUpdatePage.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from 'react'
+import { cn } from '../utils/cn'
+import Button from '../components/common/Button'
+import Modal from '../components/common/Modal'
+import MarkdownEditor from '../components/common/MarkdownEditor'
+import SingleDropdown from '../components/common/SingleDropdown'
+
+interface QuestionImage {
+  id: number
+  img_url: string
+}
+
+interface QuestionData {
+  title: string
+  content: string
+  category_id: number // 백엔드 기준
+  images?: QuestionImage[] // 기존 첨부 이미지 (미리보기 용)
+}
+
+interface QnaUpdatePageProps {
+  initialQuestion: QuestionData
+}
+
+const categoryOptions = [
+  { id: 0, name: '카테고리 선택' },
+  { id: 1, name: '개발' },
+  { id: 2, name: '디자인' },
+  { id: 3, name: '마케팅' },
+  { id: 4, name: '기획' },
+  // ... 실제 소분류(id)를 써야 함
+]
+
+const QnaUpdatePage: React.FC<QnaUpdatePageProps> = ({ initialQuestion }) => {
+  const [title, setTitle] = useState(initialQuestion.title)
+  const [content, setContent] = useState(initialQuestion.content)
+  const [categoryId, setCategoryId] = useState(initialQuestion.category_id)
+  const [showModal, setShowModal] = useState(false)
+  const [modalMessage, setModalMessage] = useState('')
+  const [imageFiles, setImageFiles] = useState<File[]>([])
+  const [previewImages, setPreviewImages] = useState<QuestionImage[]>(
+    initialQuestion.images || []
+  )
+
+  // 이미지 파일 첨부 핸들러
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return
+    const files = Array.from(e.target.files)
+    setImageFiles(files)
+    // 미리보기 (첨부된 파일들만)
+    // 만약 기존 이미지+새로 첨부한 이미지 둘 다 보여주고 싶으면 previewImages와 병합 가능
+  }
+
+  // 저장 버튼 클릭시 (현재는 디자인만)
+  const handleUpdate = () => {
+    if (!title.trim() || !content.trim() || !categoryId) {
+      setModalMessage('모든 필수값을 입력해주세요.')
+      setShowModal(true)
+      return
+    }
+    setModalMessage('질문이 수정되었습니다! (실제 저장은 API 연동 필요)')
+    setShowModal(true)
+  }
+
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto px-4 py-8 w-[944px]">
+        <h1 className="text-2xl font-bold text-gray mb-2">질문 수정하기</h1>
+        <hr className="border-gray-250 mb-8" />
+
+        <div className="bg-white rounded-lg p-6 mb-6 border border-gray-250">
+          {/* 카테고리 드롭다운 (실제 소분류 id 기준) */}
+          <div className="mb-6 w-1/3">
+            <SingleDropdown
+              options={categoryOptions.map((c) => c.name)}
+              selected={
+                categoryOptions.find((c) => c.id === categoryId)?.name || ''
+              }
+              placeholder="카테고리 선택"
+              onChange={(value) => {
+                const cat = categoryOptions.find((c) => c.name === value)
+                setCategoryId(cat ? cat.id : 0)
+              }}
+            />
+          </div>
+
+          {/* 제목 입력 */}
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="제목을 입력해 주세요 (최대 50자)"
+            maxLength={50}
+            className={cn(
+              'w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors',
+              'text-base bg-primary-50 border-gray-disabled text-gray',
+              'focus:border-primary focus:bg-gray-50'
+            )}
+          />
+
+          {/* 기존 이미지 미리보기 */}
+          {previewImages.length > 0 && (
+            <div className="mt-4 flex gap-3">
+              {previewImages.map((img) => (
+                <img
+                  key={img.id}
+                  src={img.img_url}
+                  alt="첨부 이미지"
+                  className="w-24 h-24 object-cover rounded border border-gray-250"
+                />
+              ))}
+            </div>
+          )}
+
+          {/* 이미지 파일 첨부 */}
+          <div className="mt-4">
+            <label className="block text-sm font-medium text-gray-600 mb-1">
+              이미지 첨부 (최대 5개)
+            </label>
+            <input
+              type="file"
+              multiple
+              accept="image/*"
+              onChange={handleImageChange}
+              className="block w-full text-sm text-gray-400
+                file:mr-4 file:py-2 file:px-4
+                file:rounded-lg file:border-0
+                file:text-sm file:font-semibold
+                file:bg-primary-100 file:text-primary
+                hover:file:bg-primary-50
+              "
+            />
+            {/* 첨부한 이미지 파일명 보여주기 */}
+            {imageFiles.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-600">
+                {imageFiles.map((file, i) => (
+                  <div key={i}>{file.name}</div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 내용(마크다운 에디터) */}
+        <div className="mb-6">
+          <MarkdownEditor
+            value={content}
+            onChange={setContent}
+            placeholder="내용을 입력해 주세요"
+            height="500px"
+            width="100%"
+            showPreview
+          />
+        </div>
+
+        {/* 저장 버튼 */}
+        <div className="flex justify-end">
+          <Button variant="fill" onClick={handleUpdate}>
+            저장하기
+          </Button>
+        </div>
+      </div>
+
+      {/* 모달 */}
+      <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
+        <div className="text-center py-6 px-4">
+          <h3 className="text-lg font-semibold text-gray mb-4">
+            {modalMessage}
+          </h3>
+          <Button
+            variant="fill"
+            onClick={() => setShowModal(false)}
+            className="px-8"
+          >
+            확인
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  )
+}
+
+export default QnaUpdatePage


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: `#81`

## 🔄 변경 사항

- [ ] 기능 추가


## ✔️ 변경 사항 상세 설명
	•	src/pages/QnaUpdatePage.tsx
	•	src/mocks/MockQuestionDetail.ts

	•	QnaUpdatePage 컴포넌트 목데이터 기반으로 구현 (카테고리, 제목, 본문 수정 등)


## 📸 스크린샷 (UI 변경 시 필수)
<img width="1510" alt="스크린샷 2025-07-04 오전 4 22 16" src="https://github.com/user-attachments/assets/5e9f6e41-8c4d-4f2c-a0a1-3ce44fe369fd" />


## 📝 문서화

- [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 링크 등)

## 🔍 리뷰어에게 요청 사항 (선택)


## ⚠️ 기타 주의 사항

이미지 첨부 및 content 동기화 로직(백엔드 명세상 애매한 부분) 확인요망
