### PR TITLE
feat(#78): ErrorPage 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import ErrorPage from './pages/ErrorPage'
 import HomePage from './pages/index'
 import Layout from './pages/Layout'
-import QnaListPage from './pages/QnaListPage'
+import LoginPage from './pages/LoginPage'
 import QnaDetailPage from './pages/QnaDetailPage'
+import QnaListPage from './pages/QnaListPage'
 
 function App() {
   return (
@@ -12,6 +14,8 @@ function App() {
           <Route index element={<HomePage />} />
           <Route path="/qna" element={<QnaListPage />} />
           <Route path="qna/:id" element={<QnaDetailPage />} />
+          <Route path="login" element={<LoginPage />} />
+          <Route path="*" element={<ErrorPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -1,0 +1,20 @@
+import { ErrorCode } from '../types/errorCodes'
+
+export const ERROR_MESSAGES = {
+  [ErrorCode.NOT_FOUND]: {
+    title: '404',
+    message: '페이지를 찾을 수 없습니다.',
+    description: '요청하신 페이지가 존재하지 않거나, 이동되었을 수 있습니다.',
+  },
+  [ErrorCode.INTERNAL_SERVER_ERROR]: {
+    title: '500',
+    message: '서버 오류가 발생했습니다.',
+    description:
+      '죄송합니다. 서버에서 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+  },
+  [ErrorCode.UNKNOWN]: {
+    title: 'Error :(',
+    message: '알 수 없는 오류가 발생했습니다.',
+    description: '예기치 않은 오류입니다. 홈으로 돌아가 다시 시도해 주세요.',
+  },
+}

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,33 @@
+import { Link, useLocation } from 'react-router-dom'
+import Button from '../components/common/Button'
+import { ERROR_MESSAGES } from '../constants/errorMessage'
+import { ErrorCode } from '../types/errorCodes'
+
+interface ErrorState {
+  code?: ErrorCode
+}
+
+const ErrorPage = () => {
+  const location = useLocation()
+  const state = location.state as ErrorState
+
+  const code: ErrorCode = state?.code || ErrorCode.NOT_FOUND
+
+  const getErrorMessage = (code: ErrorCode) => {
+    return ERROR_MESSAGES[code] || ERROR_MESSAGES[ErrorCode.UNKNOWN]
+  }
+  const { title, message, description } = getErrorMessage(code)
+
+  return (
+    <div className="min-h-[80vh] flex flex-col items-center justify-center">
+      <h1 className="text-9xl font-bold text-primary mb-4">{title}</h1>
+      <p className="text-xl text-gray-600 mb-2">{message}</p>
+      <p className="text-gray-500 mb-20">{description}</p>
+      <Button>
+        <Link to="/">홈으로 돌아가기</Link>
+      </Button>
+    </div>
+  )
+}
+
+export default ErrorPage

--- a/src/types/errorCodes.ts
+++ b/src/types/errorCodes.ts
@@ -1,0 +1,5 @@
+export enum ErrorCode {
+  NOT_FOUND = 404,
+  INTERNAL_SERVER_ERROR = 500,
+  UNKNOWN = 0,
+}


### PR DESCRIPTION
<!-- 제목 예시: feat(#123): 회원가입 기능 추가 -->

## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #78 


## 🔄 변경 사항

- [x] 기능 추가
- [x] 리팩토링

## ✔️ 변경 사항 상세 설명

-   **변경 파일**:
    * `src/pages/ErrorPage.tsx`
    * `src/constants/errorMessage.ts`
    * `src/types/errorCodes.ts`
    * `src/App.tsx`
    
-   **주요 구현/수정 내용**:
    * **`ErrorPage.tsx`**: 에러 코드를 기반으로 메시지를 동적으로 표시하는 에러 페이지 개발
    * **`constants/errorMessage.ts`**: HTTP 상태 코드(404, 500 등)별 에러 메시지 상수 분리 및 관리
    * **`types/errorCodes.ts`**: 에러 코드 Enum (`ErrorCode`) 정의
    * **`App.tsx` (라우팅)**:
        * 일치하는 라우트가 없을 경우 `path="*"`를 통해 `ErrorPage`를 렌더링하여 **404 Not Found** 처리
    * **`ErrorPage.tsx`**: `state?.code`가 없을 경우 **`ErrorCode.NOT_FOUND`를 기본값**으로 설정
    * **`ErrorPage.tsx`**: `ERROR_MESSAGES`에 정의되지 않은 에러 코드가 들어올 경우 **`ErrorCode.UNKNOWN`으로 폴백** 처리

### 사용법
```jsx
// 예1: useNavigate로 이동 시
navigate('/error', { state: { code: 500 } })

// 예2: Link에서
<Link to="/error" state={{ code: 404 }}>404 페이지</Link>

// 예3: API 호출 로직이 있는 어떤 컴포넌트 (서비스 파일이 될 수도 있음)
 if (!response.ok) { // HTTP 상태 코드가 200번대가 아닌 경우
  const statusCode = response.status; // 서버가 뱉어낸 HTTP 상태 코드
  console.error(`API 호출 실패: 상태 코드 ${statusCode}`);

  // ErrorPage로 이동하면서 서버에서 받은 상태 코드를 state에 담아 전달
  navigate('/error', { state: { code: statusCode as ErrorCode } });
  return; // 에러 페이지로 이동했으니 여기서 로직 종료
}
```

## 📸 스크린샷 (UI 변경 시 필수)
![localhost_5173_community](https://github.com/user-attachments/assets/f0e5d82a-73b4-4962-bba1-19e35358e02d)


## 📝 문서화

-   [ ] 관련 문서가 업데이트되었습니다. 

