### PR TITLE
feat(#5): 답변 등록 UI 구현

### DIFF
--- a/src/components/Mocks/qnaData.ts
+++ b/src/components/Mocks/qnaData.ts
@@ -1,0 +1,77 @@
+export const qnaData = {
+  id: 101,
+  title: 'Django 마이그레이션 오류 질문입니다',
+  content: 'migrate 명령 시 오류가 납니다. 해결 방법이 궁금합니다.',
+  images: ['https://cdn.ozcoding.com/media/qnaDetails/101/1.jpg'],
+  author: {
+    id: 7,
+    nickname: 'oz_student',
+    profile_image_url: 'https://cdn.ozcoding.com/profiles/user7.png',
+  },
+  category: {
+    depth_1: '백엔드',
+    depth_2: 'Python',
+    depth_3: 'Django 오류',
+  },
+  view_count: 24,
+  created_at: '2025-06-23T05:00:00Z',
+  answers: [
+    {
+      id: 201,
+      content: '# Django 마이그레이션 오류 해결 방법',
+      is_adopted: true,
+      created_at: '2025-06-23T06:00:00Z',
+      author: {
+        id: 8,
+        nickname: 'oz_helper',
+        profile_image_url: 'https://cdn.ozcoding.com/profiles/user8.png',
+      },
+      comments: [
+        {
+          id: 301,
+          content: '덕분에 해결했어요 감사합니다!',
+          created_at: '2025-06-23T07:00:00Z',
+          author: {
+            id: 7,
+            nickname: 'oz_student',
+            profile_image_url: 'https://cdn.ozcoding.com/profiles/user7.png',
+          },
+        },
+        {
+          id: 302,
+          content: '덕분에 해결했어요 감사합니다!',
+          created_at: '2025-06-23T07:00:00Z',
+          author: {
+            id: 7,
+            nickname: 'oz_student',
+            profile_image_url: 'https://cdn.ozcoding.com/profiles/user7.png',
+          },
+        },
+      ],
+    },
+    {
+      id: 202,
+      content:
+        '마이그레이션 오류는 종종 데이터베이스 스키마와 모델 간의 불일치로 발생합니다. 다음 단계를 시도해 보세요:\n\n1. `python manage.py makemigrations` 명령어로 변경 사항을 적용하세요.\n2. `python manage.py migrate` 명령어로 마이그레이션을 실행하세요.\n3. 만약 여전히 오류가 발생한다면, 데이터베이스를 초기화하고 다시 마이그레이션을 시도해 보세요.',
+      is_adopted: false,
+      created_at: '2025-06-23T06:00:00Z',
+      author: {
+        id: 8,
+        nickname: 'oz_helper',
+        profile_image_url: 'https://cdn.ozcoding.com/profiles/user8.png',
+      },
+      comments: [
+        {
+          id: 303,
+          content: '덕분에 해결했어요 감사합니다!',
+          created_at: '2025-06-23T07:00:00Z',
+          author: {
+            id: 7,
+            nickname: 'oz_student',
+            profile_image_url: 'https://cdn.ozcoding.com/profiles/user7.png',
+          },
+        },
+      ],
+    },
+  ],
+}

--- a/src/components/common/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor/MarkdownEditor.tsx
@@ -1,20 +1,21 @@
 // src/components/common/MarkdownEditor/MarkdownEditor.tsx
-import React, { useState, useRef, useCallback } from 'react'
 import { Upload, X } from 'lucide-react'
-import type { MarkdownEditorProps, ImageItem } from './MarkdownEditor.types'
-import Toolbar from './Toolbar/Toolbar'
+import React, { useCallback, useRef, useState } from 'react'
+import type { ImageItem, MarkdownEditorProps } from './MarkdownEditor.types'
 import Preview from './Preview/Preview'
+import Toolbar from './Toolbar/Toolbar'
 
-const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+const MarkdownEditor = ({
   value = '',
   onChange = () => {},
+  updateImageFiles = () => {},
   placeholder,
   height = '500px',
   width = '100%',
   showPreview: initialShowPreview = false,
   className = '',
-}) => {
-  const [content, setContent] = useState(value)
+}: MarkdownEditorProps) => {
+  const content = value
   const [images, setImages] = useState<ImageItem[]>([])
   const [showPreview, setShowPreview] = useState(initialShowPreview)
   const [selectedImageId, setSelectedImageId] = useState<string | null>(null)
@@ -28,7 +29,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 
   const handleContentChange = useCallback(
     (newContent: string) => {
-      setContent(newContent)
       onChange(newContent)
     },
     [onChange]
@@ -140,10 +140,11 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         }
 
         setImages((prev) => [...prev, imageItem])
+        updateImageFiles((prev: File[]) => [...prev, file]) // Update the parent component with the new image files
         insertImageMarkdown(imageItem, index)
       })
     },
-    [getImageCountInMarkdown, insertImageMarkdown]
+    [getImageCountInMarkdown, insertImageMarkdown, updateImageFiles]
   )
 
   const dragHandlers = {

--- a/src/components/common/MarkdownEditor/MarkdownEditor.types.ts
+++ b/src/components/common/MarkdownEditor/MarkdownEditor.types.ts
@@ -5,6 +5,7 @@ import type React from 'react'
 export interface MarkdownEditorProps {
   value?: string
   onChange?: (value: string) => void
+  updateImageFiles?: React.Dispatch<React.SetStateAction<File[]>>
   placeholder?: string
   height?: string
   width?: string

--- a/src/components/qna/AnswerForm.tsx
+++ b/src/components/qna/AnswerForm.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { useToast } from '../../hooks/useToast'
+import type { User } from '../../types/auth'
+import Avatar from '../common/Avatar'
+import Button from '../common/Button'
+import MarkdownEditor from '../common/MarkdownEditor'
+
+interface AnswerFormProps {
+  user: User
+  questionId: number
+}
+
+const AnswerForm = ({ user, questionId }: AnswerFormProps) => {
+  const [content, setContent] = useState('')
+  const [imageFiles, setImageFiles] = useState([] as File[])
+  const [isReplying, setIsReplying] = useState(false)
+  const toast = useToast()
+
+  // 답변 작성 후 저장하는 함수
+  const handleReset = () => {
+    setContent('')
+    setImageFiles([])
+    setIsReplying(false)
+  }
+  const handleSubmit = async () => {
+    const formData = new FormData()
+    formData.append('content', content) // 실제 텍스트 입력
+    imageFiles?.forEach((file) => {
+      formData.append('image_files', file) // 실제 File 객체 append
+    })
+    try {
+      if (!content.trim()) {
+        toast.show({ message: '답변 내용을 입력해주세요.', type: 'error' })
+        return
+      }
+      // const response = await axios.post(
+      //   `http://54.180.237.77/api/v1/qna/questions/${questionId}/answers/`,
+      //   formData,
+      //   {
+      //     headers: {
+      //       'Content-Type': 'multipart/form-data',
+      //       accept: 'application/json',
+      //     },
+      //   }
+      // )
+      handleReset()
+      toast.show({ message: '답변이 저장되었습니다!', type: 'success' })
+    } catch {
+      toast.show({ message: '답변 저장 실패', type: 'error' })
+    }
+  }
+  return (
+    <div className="border border-gray-250 rounded-3xl mb-25">
+      <div className="flex items-center justify-between py-10 px-9">
+        <div className="flex items-center gap-3">
+          <Avatar name={user.name} profileUrl={user.profileUrl} />
+          <div>
+            <div className="text-primary text-xs">{user.name}님, </div>
+            <div className="text-lg font-semibold text-gray-800">
+              정보를 공유해 주세요.
+            </div>
+          </div>
+        </div>
+        {isReplying ? (
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              className="px-0 rounded-full w-28"
+              onClick={handleReset}
+            >
+              취소하기
+            </Button>
+            <Button className="px-0 rounded-full w-28" onClick={handleSubmit}>
+              저장하기
+            </Button>
+          </div>
+        ) : (
+          <Button
+            className="px-0 rounded-full w-28"
+            onClick={() => setIsReplying(true)}
+          >
+            답변하기
+          </Button>
+        )}
+      </div>
+      {isReplying && (
+        <MarkdownEditor
+          placeholder="답변을 작성해주세요..."
+          value={content}
+          onChange={setContent}
+          updateImageFiles={setImageFiles}
+          showPreview
+        />
+      )}
+    </div>
+  )
+}
+
+export default AnswerForm

--- a/src/pages/QnaDetailPage.tsx
+++ b/src/pages/QnaDetailPage.tsx
@@ -2,10 +2,10 @@ import { ChevronRight, Link } from 'lucide-react'
 import { useState } from 'react'
 import UserDefaultImage from '../assets/images/common/img_user_default.png'
 import Avatar from '../components/common/Avatar'
-import Button from '../components/common/Button'
 import { mockQnaDetail } from '../components/Mocks/MockQnaDetail'
 import AIAnswer from '../components/qna/AIAnswer'
 import AnswerCard from '../components/qna/AnswerCard'
+import AnswerForm from '../components/qna/AnswerForm'
 import { useToast } from '../hooks/useToast'
 import { formatRelativeTime } from '../utils/formatRelativeTime'
 
@@ -17,10 +17,10 @@ const QnaDetailPage = () => {
     profileUrl: UserDefaultImage,
     role: 'Student',
   })
-  const toast = useToast()
   const [copied, setCopied] = useState(false)
-
   const [qnaData, setQnaData] = useState(mockQnaDetail)
+
+  const toast = useToast()
 
   const handleShare = async () => {
     try {
@@ -97,18 +97,7 @@ const QnaDetailPage = () => {
       </section>
 
       {/* 답변 요청 안내 */}
-      <div className="border border-gray-250 py-10 px-9 rounded-3xl flex items-center justify-between mb-25">
-        <div className="flex items-center gap-3">
-          <Avatar name={user.name} profileUrl={user.profileUrl} />
-          <div>
-            <div className="text-primary text-xs">{user.name}님, </div>
-            <div className="text-lg font-semibold text-gray-800">
-              정보를 공유해 주세요.
-            </div>
-          </div>
-        </div>
-        <Button className="px-0 rounded-full w-28">답변하기</Button>
-      </div>
+      {user && <AnswerForm user={user} questionId={qnaData.id} />}
 
       {/* 답변 개수 */}
       <h2 className="mb-10 flex items-center gap-4 text-2xl font-semibold">

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,8 @@
+export type User = {
+  name: string
+  userId: string
+  profileUrl: string
+}
 export interface ValidationInput {
   value: string
   isValid: boolean

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,7 +1,9 @@
 export type User = {
+  id: number
   name: string
-  userId: string
+  nickname: string
   profileUrl: string
+  role: 'Student' | 'Mentor' | 'Admin'
 }
 export interface ValidationInput {
   value: string


### PR DESCRIPTION
<!-- 제목 예시: feat(#123): 회원가입 기능 추가 -->

## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #5

## 🔄 변경 사항

* [x] 기능 추가

## ✔️ 변경 사항 상세 설명

* 변경된 파일:

  * `src/components/qna/AnswerForm.tsx`
  * `src/components/common/MarkdownEditor/*`
  * `src/pages/QnaDetailPage.tsx`
  * `src/types/auth.ts`
  * `src/components/Mocks/qnaData.ts`

* 주요 구현/수정 내용:

  * QnA 상세 페이지에서 답변 UI 영역 구현
  * 로그인된 사용자에 한해 `<AnswerForm />` 컴포넌트 렌더링
  * 마크다운 기반 에디터에서 이미지추가시 부모 이미지객체배열 추가
  * 
  * 목데이터 분리(`qnaDetailMock.ts`)로 테스트 편의성 향상

## 📸 스크린샷 (UI 변경 시 필수)

<!-- 예시 스크린샷 -->
![Jul-09-2025 01-58-27](https://github.com/user-attachments/assets/3e321057-649d-4d3a-9e11-3d897809d418)


## 📝 문서화

* [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 링크 등)

## 🔍 리뷰어에게 요청 사항 (선택)

* 이미지 업로드 구조와 부모 상태 반영 방식이 괜찮을지 확인 부탁드립니다.

## ⚠️ 기타 주의 사항

* 현재 API 연동은 주석 처리되어 있으며, 추후 연결 예정입니다.
* 마크다운에디터에서 추후 이미지업로드 api 연결 예정(url 응답)