### PR TITLE
feat(#120): 질문 상세조회 API 연동

### DIFF
--- a/src/api/qna/questionApi.ts
+++ b/src/api/qna/questionApi.ts
@@ -1,3 +1,4 @@
+import type { QuestionDetail } from '@custom-types/qnaDetail.ts'
 import { get } from '../../lib/fetcher'
 import type { Category, QuestionRawResponse } from './types.ts'
 
@@ -13,4 +14,8 @@ export const fetchQnaList = (params: QnaListParams) => {
 
 export const fetchCategories = () => {
   return get<Category[]>('/qna/questions/categories/')
+}
+
+export const fetchQnaDetail = (id: number) => {
+  return get<QuestionDetail>(`/qna/questions/${id}/`)
 }

--- a/src/components/common/MarkdownEditor/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownEditor/MarkdownRenderer.tsx
@@ -1,3 +1,4 @@
+import '@styles/markdown.css'
 import { cn } from '@utils/cn'
 import 'highlight.js/styles/github.css'
 import React, { type ComponentProps } from 'react'
@@ -36,7 +37,7 @@ const MarkdownRenderer = ({
     },
   }
   return (
-    <div className={cn(`prose prose-sm max-w-none ${className}`)}>
+    <div className={cn(`prose prose-sm max-w-none markdown-body ${className}`)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeHighlight, rehypeRaw]}

--- a/src/components/qna/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard.tsx
@@ -3,33 +3,12 @@ import Avatar from '@components/common/Avatar'
 import MarkdownRenderer from '@components/common/MarkdownEditor/MarkdownRenderer'
 import CommentInput from '@components/qna/CommentInput'
 import CommentList from '@components/qna/CommentList'
+import type { Answer, Comment } from '@custom-types/qnaDetail'
 import { cn } from '@utils/cn'
 import { formatRelativeTime } from '@utils/formatRelativeTime'
 import { MessageCircle } from 'lucide-react'
 import { useState } from 'react'
 
-interface Comment {
-  id: number | string
-  content: string
-  author: {
-    nickname: string
-    profile_image_url: string
-  }
-  created_at: string
-}
-
-interface Answer {
-  id: number | string
-  author: {
-    id: number | string
-    nickname: string
-    profile_image_url: string
-  }
-  created_at: string
-  content: string
-  comments: Comment[]
-  is_adopted?: boolean
-}
 interface AnswerCardProps {
   answer: Answer
   canAdopt: boolean

--- a/src/components/qna/AnswerForm.tsx
+++ b/src/components/qna/AnswerForm.tsx
@@ -1,23 +1,29 @@
 import Avatar from '@components/common/Avatar'
 import Button from '@components/common/Button'
 import MarkdownEditor from '@components/common/MarkdownEditor'
-import type { User } from '@custom-types/auth'
 import { useToast } from '@hooks/useToast'
+import { useAuthStore } from '@store/authStore'
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
 interface AnswerFormProps {
-  user: User
   questionId: number
 }
 
-const AnswerForm = ({ user, questionId }: AnswerFormProps) => {
+const AnswerForm = ({ questionId }: AnswerFormProps) => {
+  const { user } = useAuthStore()
   const [content, setContent] = useState('')
   const [imageFiles, setImageFiles] = useState([] as File[])
   const [isReplying, setIsReplying] = useState(false)
   const toast = useToast()
 
   const navigate = useNavigate()
+
+  if (!user) {
+    return null
+  }
+  const { nickname, profile_image_url: profileUrl } = user
+
   // 답변 작성 후 저장하는 함수
   const handleReset = () => {
     setContent('')
@@ -35,16 +41,6 @@ const AnswerForm = ({ user, questionId }: AnswerFormProps) => {
         toast.show({ message: '답변 내용을 입력해주세요.', type: 'error' })
         return
       }
-      // const response = await axios.post(
-      //   `http://54.180.237.77/api/v1/qna/questions/${questionId}/answers/`,
-      //   formData,
-      //   {
-      //     headers: {
-      //       'Content-Type': 'multipart/form-data',
-      //       accept: 'application/json',
-      //     },
-      //   }
-      // )
       handleReset()
       toast.show({ message: '답변이 저장되었습니다!', type: 'success' })
       navigate(`/qna/${questionId}`) // 답변 저장 후 해당 질문 페이지로 이동
@@ -56,9 +52,9 @@ const AnswerForm = ({ user, questionId }: AnswerFormProps) => {
     <div className="border border-gray-250 rounded-3xl mb-25">
       <div className="flex items-center justify-between py-10 px-9">
         <div className="flex items-center gap-3">
-          <Avatar name={user.name} profileUrl={user.profileUrl} />
+          <Avatar name={nickname} profileUrl={profileUrl} />
           <div>
-            <div className="text-primary text-xs">{user.name}님, </div>
+            <div className="text-primary text-xs">{nickname}님, </div>
             <div className="text-lg font-semibold text-gray-800">
               정보를 공유해 주세요.
             </div>

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,0 +1,37 @@
+@reference "tailwindcss";
+
+.markdown-body h1 {
+  @apply text-3xl font-bold mt-6 mb-4;
+}
+
+.markdown-body h2 {
+  @apply text-2xl font-semibold mt-5 mb-3;
+}
+
+.markdown-body h3 {
+  @apply text-xl font-semibold mt-4 mb-2;
+}
+
+.markdown-body p {
+  @apply my-2 leading-relaxed text-gray-800;
+}
+
+.markdown-body ul {
+  @apply list-disc ml-6 pl-2 my-2;
+}
+
+.markdown-body ol {
+  @apply list-decimal ml-6 pl-2 my-2;
+}
+
+.markdown-body li {
+  @apply mb-1;
+}
+
+.markdown-body code {
+  @apply bg-gray-100 rounded px-1 py-0.5 text-sm font-mono;
+}
+
+.markdown-body pre {
+  @apply bg-gray-100 rounded px-4 py-3 my-4 overflow-x-auto text-sm;
+}

--- a/src/types/qnaDetail.ts
+++ b/src/types/qnaDetail.ts
@@ -1,24 +1,37 @@
-export interface Comment {
+export interface Image {
   id: number
-  content: string
+  img_url: string
   created_at: string
-  author: {
-    id: number
-    nickname: string
-    profile_image_url: string
-  }
+  updated_at: string
 }
 
+export interface Author {
+  id?: number // 질문 작성자엔 id 없음, 답변/댓글 작성자엔 id 있음
+  nickname: string
+  profile_image_url: string
+}
+
+export interface Comment {
+  id: number
+  answer_id: number
+  author: Author
+  content: string
+  created_at: string
+  updated_at: string
+}
+export interface AnswerImage {
+  id: number
+  img_url: string
+}
 export interface Answer {
   id: number
+  question_id: number
+  author: Author
   content: string
   is_adopted: boolean
   created_at: string
-  author: {
-    id: number
-    nickname: string
-    profile_image_url: string
-  }
+  updated_at: string
+  img_url: AnswerImage[]
   comments: Comment[]
 }
 
@@ -39,4 +52,20 @@ export interface Question {
   view_count: number
   created_at: string
   thumbnail: string
+}
+
+export interface QuestionDetail {
+  id: number
+  title: string
+  content: string
+  images: Image[]
+  author: Author
+  category: {
+    major: string
+    middle: string
+    minor: string
+  }
+  view_count: number
+  created_at: string
+  answers: Answer[]
 }


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #120
## 🔄 변경 사항

- [x] 기능 추가
- [x] 리팩토링

## ✔️ 변경 사항 상세 설명

- 변경된 파일:
  - `src/pages/QnaDetailPage.tsx`
  - `src/api/qna/questionApi.ts`
  - `src/types/qnaDetail.ts`
  - `src/components/qna/AnswerCard.tsx`
  - `src/components/qna/AnswerForm.tsx`

- 주요 구현/수정 내용:
  - `fetchQnaDetail(id)` API 함수 추가 및 타입 정의 (`QuestionDetail`)
  - `QnaDetailPage`에서 mock 제거 후 실제 API 호출 적용
  - `useParams`로 질문 ID 받아와 fetch → 질문 데이터 상태로 관리
  - 마크다운 렌더러로 질문 본문 렌더링
  - 답변/댓글 타입 통합 및 AnswerCard에 적용
  - 답변 작성자 정보 `useAuthStore`에서 받아 렌더링
  - 답변 없을 경우 메시지 처리 및 오류 발생 시 뒤로가기 처리

## 📸 스크린샷 (UI 변경 시 필수)
<img width="500" height="2935" alt="localhost_5173_qna_20" src="https://github.com/user-attachments/assets/5697d9bc-8fba-4ac1-aa42-265833429ef0" />


## 📝 문서화

- [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 링크 등)

## 🔍 리뷰어에게 요청 사항 (선택)

- 전체적인 API 연동 흐름 및 상태 초기화 방식이 자연스러운지 확인 부탁드립니다.
- 타입 구조가 과하게 복잡하지 않은지도 검토 요청드립니다.

## ⚠️ 기타 주의 사항

- 현재 채택 처리 API는 미연동 상태이며 추후 별도 구현 예정입니다.
