### PR TITLE
refactor(#143): button컴포넌트 to props추가

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,7 +1,7 @@
 //src/components/common/Button/Button.tsx
 import { cn } from '@utils/cn'
-import React from 'react'
 import type { ButtonProps } from './Button.types'
+import { Link } from 'react-router-dom'
 
 const Button = ({
   variant = 'fill',
@@ -10,6 +10,7 @@ const Button = ({
   children,
   onClick,
   type = 'button',
+  to,
 }: ButtonProps) => {
   const variantMap = {
     fill: 'bg-primary text-white hover:bg-primary-600 active:bg-primary-700',
@@ -25,6 +26,22 @@ const Button = ({
       return 'bg-gray-200 text-gray-250 cursor-not-allowed'
     }
     return variantMap[variant] || variantMap.fill
+  }
+
+  if (to) {
+    return (
+      <Link
+        to={to}
+        className={cn(
+          'font-semibold focus:outline-none transition-colors rounded-sm py-3 px-12',
+          getStyles(),
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+          className
+        )}
+      >
+        {children}
+      </Link>
+    )
   }
 
   return (

--- a/src/components/common/Button/Button.types.ts
+++ b/src/components/common/Button/Button.types.ts
@@ -6,4 +6,5 @@ export interface ButtonProps {
   children: React.ReactNode
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
   type?: 'button' | 'submit' | 'reset'
+  to?: string
 }


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: `#143`


## ✔️ 변경 사항 상세 설명

Button.tsx
Button.types.ts

버튼을 이용해 link를 쓰기위해
props에 to 를 추가함


