### PR TITLE
feat(#118): 답변 채택 API 연동

### DIFF
--- a/src/api/qna/answerApi.ts
+++ b/src/api/qna/answerApi.ts
@@ -1,0 +1,11 @@
+import { post } from '@lib/fetcher'
+import type { AdoptAnswerParams, AdoptAnswerResponse } from './types'
+
+export const fetchAdoptedAnswer = ({
+  answer_id,
+  question_id,
+}: AdoptAnswerParams) => {
+  return post<AdoptAnswerResponse>(
+    `/qna/questions/${question_id}/answers/${answer_id}/adopt/`
+  )
+}

--- a/src/api/qna/questionApi.ts
+++ b/src/api/qna/questionApi.ts
@@ -1,9 +1,9 @@
 import type { QuestionDetail } from '@custom-types/qnaDetail.ts'
-import { get, post } from '../../lib/fetcher'
+import { get, post } from '@lib/fetcher'
 import type {
   Category,
-  QuestionRawResponse,
   CreateQuestionRequest,
+  QuestionRawResponse,
 } from './types.ts'
 
 export interface QnaListParams {

--- a/src/api/qna/types.ts
+++ b/src/api/qna/types.ts
@@ -31,3 +31,17 @@ export interface CreateQuestionRequest {
   title: string
   content: string
 }
+export interface QnaListParams {
+  ordering?: string
+  page?: number
+  page_size?: number
+  search?: string
+}
+export interface AdoptAnswerParams {
+  answer_id: number
+  question_id: number
+}
+
+export interface AdoptAnswerResponse {
+  message: string
+}

--- a/src/components/qna/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard.tsx
@@ -11,8 +11,8 @@ import { useState } from 'react'
 
 interface AnswerCardProps {
   answer: Answer
-  canAdopt: boolean
-  onAdopt: (answerId: number | string) => void
+  canAdopt: boolean | null
+  onAdopt: (answerId: number) => void
 }
 
 function AnswerCard({ answer, canAdopt, onAdopt }: AnswerCardProps) {


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #118 

## 🔄 변경 사항

- [x] 기능 추가
- [x] 리팩토링

## ✔️ 변경 사항 상세 설명

- 변경된 파일:
  - `src/api/qna/answerApi.ts`
  - `src/api/qna/types.ts`
  - `src/pages/QnaDetailPage.tsx`
  - `src/components/qna/AnswerCard.tsx`

- 주요 구현/수정 내용:
  - 답변 채택 API(`fetchAdoptedAnswer`) 구현 및 응답 타입(`AdoptAnswerResponse`) 정의
  - `QnaDetailPage`에서 zustand의 `user` 정보 연동
  - 답변 채택 시 API 호출 후 `QnA 상세 데이터` 재조회하여 상태 반영
  - `AnswerCard`에서 `onAdopt` 콜백 타입 명확화 (`number` 고정)

## 📸 스크린샷 (UI 변경 시 필수)
![답변채택](https://github.com/user-attachments/assets/b327d497-3e0f-4554-8ba3-504975c0027e)


## 📝 문서화

- [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 링크 등)

## 🔍 리뷰어에게 요청 사항 (선택)

- 채택 후 리렌더링 방식이 자연스러운지 확인 부탁드립니다.
- API 응답 메시지를 그대로 사용자에게 보여주는 방식이 괜찮을지 검토해주세요.

## ⚠️ 기타 주의 사항
