### PR TITLE
fix(#153): 로그인 핸들러를 form submit으로 변경하고 로그아웃 시 auth-storage 제거

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -180,7 +180,7 @@ export default function LoginPage() {
     setFindPwStep('form')
   }
 
-  const handleLogin = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     try {
       const result = await emailLogin({
@@ -209,7 +209,7 @@ export default function LoginPage() {
   return (
     <div className="flex justify-center">
       <div className="mt-[200px] mb-[392px] w-[348px] h-[488px]">
-        <form>
+        <form onSubmit={handleLogin}>
           <AuthHeader
             message="아직 회원이 아니신가요?"
             linkText="회원가입하기"
@@ -273,10 +273,11 @@ export default function LoginPage() {
 
           <div className="mt-[12px]">
             <Button
+              type="submit"
               variant={isFormValid ? 'fill' : 'ghost'}
               disabled={!isFormValid}
               className="w-[348px] h-[52px]"
-              onClick={handleLogin}
+              // onClick={handleLogin}
             >
               일반회원 로그인
             </Button>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -128,15 +128,7 @@ export const useAuthStore = create<AuthState>()(
       // 로그아웃
       logout: async (): Promise<void> => {
         try {
-          await AuthApi.logout()
-        } catch (error: unknown) {
-          if (axios.isAxiosError<{ message: string }>(error)) {
-            // eslint-disable-next-line no-console
-            console.error(`[AxiosError] 로그아웃 API 호출 실패 ${error ?? ''}`)
-          }
-          // eslint-disable-next-line no-console
-          console.error('[UnexpectedError]', error)
-        } finally {
+          // await AuthApi.logout()
           set({
             user: null,
             accessToken: null,
@@ -144,6 +136,11 @@ export const useAuthStore = create<AuthState>()(
             isAuthenticated: false,
             isLoading: false,
           })
+
+          localStorage.removeItem('auth-storage')
+        } catch (error: unknown) {
+          // eslint-disable-next-line no-console
+          console.error('[UnexpectedError]', error)
         }
       },
 


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #153

## 🔄 변경 사항

<!-- 해당되는 항목만 남기고 삭제하세요 -->

- [x] 기능 추가
- [x] 버그 수정

## ✔️ 변경 사항 상세 설명

- 변경된 파일: 
  - `src/pages/LoginPage.tsx`
  - `src/store/authStore.ts`
- 주요 구현/수정 내용:

  - 로그인 시 `<form>` 태그의 `onSubmit` 이벤트가 아닌 버튼의 `onClick` 이벤트를 사용하던 문제 수정
    - 사용자가 Enter 키를 눌러도 로그인되지 않는 문제 발생 가능성 있음
    - `handleLogin`을 `<form onSubmit={handleLogin}>`으로 이전하여 기본 HTML 폼 동작에 맞도록 개선

  - 로그아웃 시 zustand 상태만 초기화되고, localStorage에 저장된 `auth-storage` 키는 삭제되지 않던 문제 해결
    - 로그아웃 후에도 localStorage에 이전 로그인 정보가 남아 있어 `initialize()` 시 의도치 않게 인증 상태로 인식될 수 있었음
    - 로그아웃 시 `localStorage.removeItem('auth-storage')` 추가하여 완전한 로그아웃 처리 적용
    - 로그아웃 api는 따로없어서 fetch부분 삭제
## 📸 스크린샷 (UI 변경 시 필수)

<!-- UI 변경이 있을 경우 스크린샷을 첨부하세요 -->
<!-- 예: ![스크린샷](링크) -->

## 📝 문서화

- [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 링크 등)

## 🔍 리뷰어에게 요청 사항 (선택)

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 작성하세요 -->
<!-- 예: 에러 핸들링 방식 괜찮을지 확인 부탁드립니다. -->

## ⚠️ 기타 주의 사항

<!-- 긴급 처리 필요, 병합 순서, 의존성 등 주의 사항이 있다면 작성하세요 -->
<!-- 예: 이 PR은 hotfix이므로 빠른 병합이 필요합니다. -->
