### PR TITLE
 feat(#152): 질문수정페이지 api 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import QnaListPage from '@pages/QnaListPage'
 import SignUpFormPage from '@pages/SignUpFormPage'
 import SignUpPage from '@pages/SignUpPage'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import QnaEditPage from '@pages/QnaEditPage'
 
 function App() {
   return (
@@ -28,6 +29,7 @@ function App() {
           <Route path="changePassword" element={<ChangePasswordPage />} />
           <Route path="qna/create" element={<QnaCreatePage />} />
           <Route path="*" element={<ErrorPage />} />
+          <Route path="qna/:id/edit" element={<QnaEditPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/api/qna/questionApi.ts
+++ b/src/api/qna/questionApi.ts
@@ -1,5 +1,5 @@
 import type { QuestionDetail } from '@custom-types/qnaDetail.ts'
-import { get, post } from '@lib/fetcher'
+import { get, post, patch } from '@lib/fetcher'
 import type {
   Category,
   CreateQuestionRequest,
@@ -25,4 +25,10 @@ export const fetchQnaDetail = (id: number) => {
 }
 export const createQuestion = (payload: CreateQuestionRequest) => {
   return post('/qna/questions/create/', payload)
+}
+export const updateQuestion = (
+  questionId: number,
+  payload: CreateQuestionRequest
+) => {
+  return patch(`/qna/questions/${questionId}/update/`, payload)
 }

--- a/src/components/qna/QnaCategorySelect.tsx
+++ b/src/components/qna/QnaCategorySelect.tsx
@@ -10,10 +10,12 @@ interface SelectedCategories {
 }
 
 interface QnaCategorySelectProps {
+  value?: number | null
   onCategoryChange?: (categoryId: number | null) => void
 }
 
 export default function QnaCategorySelect({
+  value,
   onCategoryChange,
 }: QnaCategorySelectProps) {
   const [categories, setCategories] = useState<Category[]>([])
@@ -30,6 +32,33 @@ export default function QnaCategorySelect({
   useEffect(() => {
     fetchCategories().then((data) => setCategories(data))
   }, [])
+
+  useEffect(() => {
+    if (value && categories.length > 0) {
+      // 소분류 ID로부터 대분류-중분류-소분류 찾기
+      const findCategoryPath = (minorId: number) => {
+        for (const major of categories) {
+          if (major.child_categories) {
+            for (const middle of major.child_categories) {
+              if (middle.child_categories) {
+                const minor = middle.child_categories.find(
+                  (m) => m.id === minorId
+                )
+                if (minor) {
+                  return { major, middle, minor }
+                }
+              }
+            }
+          }
+        }
+        return null
+      }
+      const categoryPath = findCategoryPath(value)
+      if (categoryPath) {
+        setSelected(categoryPath)
+      }
+    }
+  }, [value, categories])
 
   const majorOptions = categories.map((item) => ({
     id: item.id,
@@ -58,7 +87,6 @@ export default function QnaCategorySelect({
     setOpenDropdown((prev) => (prev === type ? null : type))
   }
 
-  // 👇 각 선택 함수 추가!
   const handleMajor = (name: string) => {
     const major = categories.find((cat) => cat.name === name) || null
     setSelected({ major, middle: null, minor: null })

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -87,6 +87,15 @@ export const put = async <T>(
   return response.data
 }
 
+export const patch = async <T>(
+  url: string,
+  data?: unknown,
+  config?: AxiosRequestConfig
+): Promise<T> => {
+  const response = await fetcher.patch<T>(url, data, config)
+  return response.data
+}
+
 export const del = async <T>(
   url: string,
   config?: AxiosRequestConfig

--- a/src/pages/QnaDetailPage.tsx
+++ b/src/pages/QnaDetailPage.tsx
@@ -1,6 +1,7 @@
 import { fetchAdoptedAnswer } from '@api/qna/answerApi'
 import { fetchQnaDetail } from '@api/qna/questionApi'
 import Avatar from '@components/common/Avatar'
+import Button from '@components/common/Button'
 import MarkdownRenderer from '@components/common/MarkdownEditor/MarkdownRenderer'
 import AIAnswer from '@components/qna/AIAnswer'
 import AnswerCard from '@components/qna/AnswerCard'
@@ -67,6 +68,8 @@ const QnaDetailPage = () => {
     user.nickname === qnaData.author.nickname &&
     !qnaData.answers.some((a) => a.is_adopted)
 
+  const canEdit = user && user.nickname === qnaData.author.nickname
+
   const handleAdopt = (answerId: number) => {
     const fetchData = async () => {
       try {
@@ -114,24 +117,38 @@ const QnaDetailPage = () => {
               <span className="text-primary text-4xl mr-4">Q.</span>{' '}
               {qnaData.title}
             </h1>
+
             <div className="flex items-center gap-3 shrink-0">
               <Avatar
                 name={qnaData.author.nickname}
                 profileUrl={qnaData.author.profile_image_url}
               />
+
               <div className="text-gray-600">{qnaData.author.nickname} </div>
             </div>
           </div>
 
-          <div className="text-sm text-gray-400">
-            조회 {qnaData.view_count} · {formatRelativeTime(qnaData.created_at)}
+          <div className="flex items-center justify-between text-sm text-gray-400">
+            <div>
+              조회 {qnaData.view_count} ·{' '}
+              {formatRelativeTime(qnaData.created_at)}
+            </div>
+            {canEdit && (
+              <Button
+                variant="check"
+                className="flex items-center gap-1 px-4 py-2 text-xs"
+                onClick={() => navigate(`/qna/${questionId}/edit`)}
+              >
+                수정
+              </Button>
+            )}
           </div>
         </div>
         <div className="pt-10 text-body-rg pb-15">
           <MarkdownRenderer content={qnaData.content} />
         </div>
         <AIAnswer question={qnaData.content} />
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
           <button
             type="button"
             className="text-sm font-semibold flex items-center gap-2 text-gray-400 py-2 px-3 rounded-full border border-gray-250 cursor-pointer"

--- a/src/pages/QnaDetailPage.tsx
+++ b/src/pages/QnaDetailPage.tsx
@@ -135,9 +135,10 @@ const QnaDetailPage = () => {
             </div>
             {canEdit && (
               <Button
+                to={`/qna/${questionId}/edit`}
                 variant="check"
                 className="flex items-center gap-1 px-4 py-2 text-xs"
-                onClick={() => navigate(`/qna/${questionId}/edit`)}
+                onClick={() => {}}
               >
                 수정
               </Button>

--- a/src/pages/QnaEditPage.tsx
+++ b/src/pages/QnaEditPage.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import QnaCategorySelect from '@components/qna/QnaCategorySelect'
+import QnaTitleInput from '@components/qna/QnaTitleInput'
+import MarkdownEditor from '@components/common/MarkdownEditor/MarkdownEditor'
+import Button from '@components/common/Button'
+import { useToast } from '@hooks/useToast'
+import {
+  fetchQnaDetail,
+  updateQuestion,
+  fetchCategories,
+} from '@api/qna/questionApi'
+import type { CreateQuestionRequest, Category } from '@api/qna/types'
+
+export default function QnaEditPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+
+  const [categoryId, setCategoryId] = useState<number | null>(null)
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // 카테고리 이름으로 소분류 ID 찾기
+  const findMinorCategoryId = (
+    categories: Category[],
+    majorName: string,
+    middleName: string,
+    minorName: string
+  ): number | null => {
+    for (const major of categories) {
+      if (major.name === majorName && major.child_categories) {
+        for (const middle of major.child_categories) {
+          if (middle.name === middleName && middle.child_categories) {
+            const minor = middle.child_categories.find(
+              (m) => m.name === minorName
+            )
+            if (minor) return minor.id
+          }
+        }
+      }
+    }
+    return null
+  }
+
+  // 기존 질문 데이터 로딩
+  useEffect(() => {
+    const loadQuestionData = async () => {
+      if (!id) {
+        toast.show({ message: '잘못된 접근입니다.', type: 'error' })
+        navigate('/qna')
+        return
+      }
+
+      try {
+        const [questionData, categoriesData] = await Promise.all([
+          fetchQnaDetail(Number(id)),
+          fetchCategories(),
+        ])
+
+        // 카테고리 이름으로 실제 ID 찾기
+        const foundCategoryId = findMinorCategoryId(
+          categoriesData,
+          questionData.category.major,
+          questionData.category.middle,
+          questionData.category.minor
+        )
+
+        setCategoryId(foundCategoryId)
+        setTitle(questionData.title)
+        setContent(questionData.content)
+      } catch (error) {
+        toast.show({
+          message: '질문을 불러오는데 실패했습니다.',
+          type: 'error',
+        })
+        navigate('/qna')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadQuestionData()
+  }, [id, navigate, toast])
+
+  // 폼 유효성 검사
+  const isFormValid =
+    !!categoryId &&
+    title.trim() !== '' &&
+    content.trim() !== '' &&
+    !isSubmitting
+
+  // 질문 수정 처리
+  const handleUpdateQuestion = async () => {
+    if (!isFormValid) {
+      toast.show({ message: '필수 항목을 모두 입력해 주세요.', type: 'error' })
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const requestData: CreateQuestionRequest = {
+        category_id: categoryId,
+        title: title.trim(),
+        content: content.trim(),
+      }
+
+      await updateQuestion(Number(id), requestData)
+      toast.show({ message: '질문이 수정되었습니다!', type: 'success' })
+      navigate(`/qna/${id}`)
+    } catch (error) {
+      toast.show({ message: '질문 수정에 실패했습니다.', type: 'error' })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleCancelEdit = () => {
+    navigate(`/qna/${id}`)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto mb-2" />
+          <p className="text-gray-600">질문을 불러오는 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto px-4 py-8 w-[944px]">
+        <header className="mb-8">
+          <h1 className="text-2xl font-bold text-gray mb-3">질문 수정하기</h1>
+          <hr className="border-gray-250" />
+        </header>
+
+        <section className="rounded-lg p-6 mb-6 border border-gray-250">
+          <div className="mb-6">
+            <QnaCategorySelect
+              value={categoryId}
+              onCategoryChange={setCategoryId}
+            />
+          </div>
+          <QnaTitleInput value={title} onChange={setTitle} />
+        </section>
+
+        <section className="mb-6">
+          <MarkdownEditor
+            value={content}
+            onChange={setContent}
+            placeholder="내용을 입력해 주세요."
+            showPreview
+          />
+        </section>
+
+        <footer className="flex justify-end gap-2">
+          <Button
+            onClick={handleCancelEdit}
+            variant="outline"
+            disabled={isSubmitting}
+          >
+            취소
+          </Button>
+          <Button onClick={handleUpdateQuestion} disabled={!isFormValid}>
+            {isSubmitting ? '수정 중...' : '수정하기'}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #152

## 🔄 변경 사항

- [x] 기능 추가
- [x] 리팩토링
- [x] 스타일 수정

## ✔️ 변경 사항 상세 설명

QnaEditPage 구현 / Api 연동
컨텐츠를 불러오면서 카테고리 소분류id로카테고리 초기값을 찾아와야해서 
QnaCategorySelect에 초기값 설정
QnaDetailPage에 수정버튼 추가

