### PR TITLE
feat(#119): 답변 댓글 등록 API 구현

### DIFF
--- a/src/api/qna/answerApi.ts
+++ b/src/api/qna/answerApi.ts
@@ -1,5 +1,9 @@
 import { post } from '@lib/fetcher'
-import type { AdoptAnswerParams, AdoptAnswerResponse } from './types'
+import type {
+  AdoptAnswerParams,
+  AdoptAnswerResponse,
+  CreateCommentResponse,
+} from './types'
 
 export const fetchAdoptedAnswer = ({
   answer_id,
@@ -7,5 +11,15 @@ export const fetchAdoptedAnswer = ({
 }: AdoptAnswerParams) => {
   return post<AdoptAnswerResponse>(
     `/qna/questions/${question_id}/answers/${answer_id}/adopt/`
+  )
+}
+
+export const fetchCreateComment = (
+  answer_id: number,
+  content: string
+): Promise<CreateCommentResponse> => {
+  return post<CreateCommentResponse>(
+    `/qna/questions/answers/${answer_id}/comments/`,
+    { content }
   )
 }

--- a/src/api/qna/answerApi.ts
+++ b/src/api/qna/answerApi.ts
@@ -14,7 +14,7 @@ export const fetchAdoptedAnswer = ({
   )
 }
 
-export const fetchCreateComment = (
+export const createComment = (
   answer_id: number,
   content: string
 ): Promise<CreateCommentResponse> => {

--- a/src/api/qna/types.ts
+++ b/src/api/qna/types.ts
@@ -31,7 +31,7 @@ export interface CreateQuestionRequest {
   title: string
   content: string
 }
-export interface fetchCreateCommentParams {
+export interface createCommentParams {
   answer_id: number
   content: string
 }

--- a/src/api/qna/types.ts
+++ b/src/api/qna/types.ts
@@ -31,6 +31,14 @@ export interface CreateQuestionRequest {
   title: string
   content: string
 }
+export interface fetchCreateCommentParams {
+  answer_id: number
+  content: string
+}
+
+export interface CreateCommentResponse {
+  message: string
+}
 export interface QnaListParams {
   ordering?: string
   page?: number

--- a/src/components/qna/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard.tsx
@@ -3,7 +3,7 @@ import Avatar from '@components/common/Avatar'
 import MarkdownRenderer from '@components/common/MarkdownEditor/MarkdownRenderer'
 import CommentInput from '@components/qna/CommentInput'
 import CommentList from '@components/qna/CommentList'
-import type { Answer, Comment } from '@custom-types/qnaDetail'
+import type { Answer } from '@custom-types/qnaDetail'
 import { cn } from '@utils/cn'
 import { formatRelativeTime } from '@utils/formatRelativeTime'
 import { MessageCircle } from 'lucide-react'
@@ -13,34 +13,22 @@ interface AnswerCardProps {
   answer: Answer
   canAdopt: boolean | null
   onAdopt: (answerId: number) => void
+  onAddComment: (answerId: number, text: string) => void
 }
 
-function AnswerCard({ answer, canAdopt, onAdopt }: AnswerCardProps) {
-  const [comments, setComments] = useState<Comment[]>(answer.comments)
+const AnswerCard = ({
+  answer,
+  canAdopt,
+  onAdopt,
+  onAddComment,
+}: AnswerCardProps) => {
   const [orderByDesc, setOrderByDesc] = useState(true)
 
-  const sortedComments = [...comments].sort((a, b) => {
+  const sortedComments = [...answer.comments].sort((a, b) => {
     const aTime = new Date(a.created_at).getTime()
     const bTime = new Date(b.created_at).getTime()
     return orderByDesc ? bTime - aTime : aTime - bTime
   })
-
-  // 댓글 등록
-  const handleAddComment = (text: string) => {
-    const newComment: Comment = {
-      id: Math.random().toString(36).slice(2),
-      content: text,
-      author: {
-        nickname: '백지헌',
-        profile_image_url:
-          'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSEg4LXysUccw39DpXCFKIRkJv6-mzFCNl7fw&s',
-      },
-      created_at: new Date().toISOString(),
-    }
-    setComments((prev) =>
-      orderByDesc ? [newComment, ...prev] : [...prev, newComment]
-    )
-  }
 
   return (
     <div
@@ -89,7 +77,9 @@ function AnswerCard({ answer, canAdopt, onAdopt }: AnswerCardProps) {
       <div className="flex items-center justify-between mb-5 mt-6 pt-4 text-sm text-gray-700">
         <div className="flex items-center gap-3 font-semibold">
           <MessageCircle />
-          <span className="font-bold text-xl">댓글 {comments.length}개</span>
+          <span className="font-bold text-xl">
+            댓글 {answer.comments.length}개
+          </span>
         </div>
         <button
           type="button"
@@ -104,7 +94,7 @@ function AnswerCard({ answer, canAdopt, onAdopt }: AnswerCardProps) {
       </div>
 
       {/* 댓글 입력창 */}
-      <CommentInput onSubmit={handleAddComment} />
+      <CommentInput onSubmit={(text) => onAddComment(answer.id, text)} />
 
       {/* 댓글 목록 */}
       <CommentList comments={sortedComments} className="mt-2" />

--- a/src/components/qna/CommentInput.tsx
+++ b/src/components/qna/CommentInput.tsx
@@ -1,8 +1,7 @@
 import Button from '@components/common/Button/Button'
 import Textarea from '@components/common/Textarea'
-import { ToastContext } from '@components/common/Toast/ToastContext'
 import { cn } from '@utils/cn'
-import React, { useContext, useState } from 'react'
+import React, { useState } from 'react'
 const NOTICE =
   '개인정보를 공유 및 요청하거나, 명예 훼손, 무단 광고, 불법 정보 유포시 모니터링 후 삭제될 수 있습니다.'
 const DEFAULT_MAX_LENGTH = 300
@@ -19,17 +18,12 @@ function CommentInput({
   className = '',
 }: CommentInputProps) {
   const [value, setValue] = useState('')
-  const toast = useContext(ToastContext)
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     const trimmed = value.trim()
     if (!trimmed) return
     onSubmit(trimmed)
     setValue('')
-    toast?.show({
-      type: 'success',
-      message: '댓글이 등록되었어요.',
-    })
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/components/qna/CommentItem.tsx
+++ b/src/components/qna/CommentItem.tsx
@@ -1,6 +1,6 @@
 import Avatar from '@components/common/Avatar'
 import { cn } from '@utils/cn'
-import { getFullDate } from '@utils/getFullDate'
+import { formatRelativeTime } from '@utils/formatRelativeTime'
 
 interface CommentItemProps {
   comment: {
@@ -34,7 +34,7 @@ function CommentItem({ comment, className = '' }: CommentItemProps) {
             {comment.author.nickname}
           </span>
           <span className="text-xs text-gray-400">
-            {getFullDate(comment.created_at)}
+            {formatRelativeTime(comment.created_at)}
           </span>
         </div>
         <div className="whitespace-pre-wrap break-words text-gray-800">

--- a/src/pages/QnaDetailPage.tsx
+++ b/src/pages/QnaDetailPage.tsx
@@ -1,4 +1,4 @@
-import { fetchAdoptedAnswer } from '@api/qna/answerApi'
+import { fetchAdoptedAnswer, fetchCreateComment } from '@api/qna/answerApi'
 import { fetchQnaDetail } from '@api/qna/questionApi'
 import Avatar from '@components/common/Avatar'
 import Button from '@components/common/Button'
@@ -54,6 +54,28 @@ const QnaDetailPage = () => {
       toast.show({ message: 'URL이 복사되었습니다!', type: 'success' })
     } catch {
       toast.show({ message: 'URL 복사 실패', type: 'error' })
+    }
+  }
+
+  // 댓글 등록
+  const handleAddComment = async (answerId: number, content: string) => {
+    try {
+      await fetchCreateComment(answerId, content)
+      toast.show({
+        message: '댓글이 등록되었습니다.',
+        type: 'success',
+      })
+      const updatedQna = await fetchQnaDetail(Number(questionId))
+      setQnaData(updatedQna)
+    } catch (error: unknown) {
+      if (axios.isAxiosError<{ message: string }>(error)) {
+        // eslint-disable-next-line no-console
+        console.error('댓글등록 중 오류 발생:', error.message)
+        toast.show({
+          message: error.message || '댓글등록에 실패했습니다. ',
+          type: 'error',
+        })
+      }
     }
   }
 
@@ -187,6 +209,7 @@ const QnaDetailPage = () => {
             answer={answer}
             canAdopt={canAdopt}
             onAdopt={handleAdopt}
+            onAddComment={handleAddComment}
           />
         ))}
       </div>

--- a/src/pages/QnaDetailPage.tsx
+++ b/src/pages/QnaDetailPage.tsx
@@ -1,4 +1,4 @@
-import { fetchAdoptedAnswer, fetchCreateComment } from '@api/qna/answerApi'
+import { createComment, fetchAdoptedAnswer } from '@api/qna/answerApi'
 import { fetchQnaDetail } from '@api/qna/questionApi'
 import Avatar from '@components/common/Avatar'
 import Button from '@components/common/Button'
@@ -60,7 +60,7 @@ const QnaDetailPage = () => {
   // 댓글 등록
   const handleAddComment = async (answerId: number, content: string) => {
     try {
-      await fetchCreateComment(answerId, content)
+      await createComment(answerId, content)
       toast.show({
         message: '댓글이 등록되었습니다.',
         type: 'success',


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #119 

## 🔄 변경 사항

* [x] 기능 추가
* [x] 리팩토링

## ✔️ 변경 사항 상세 설명

* `fetchCreateComment(answer_id, content)` 함수 추가 → 이후 `createComment`로 함수명 리팩토링

  * POST 요청으로 특정 답변에 대한 댓글 생성
  * 관련 타입 `fetchCreateCommentParams`, `CreateCommentResponse` 정의
* `AnswerCard` → `QnaDetailPage`로 댓글 등록 로직 위임 (관심사 분리)

  * `handleAddComment` 함수에서 댓글 등록 후 `fetchQnaDetail()`로 질문 상세 재요청
* `CommentInput` 컴포넌트에서 토스트 로직 제거 → 부모 컴포넌트에서 제어
* 댓글 시간 포맷을 `getFullDate` → `formatRelativeTime`으로 통일
* API 함수명 `fetchCreateComment` → `createComment`로 변경하여 의미 명확화

## 📸 스크린샷 (UI 변경 시 필수)

* 해당 없음

## 📝 문서화

* [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 등)

## 🔍 리뷰어에게 요청 사항

* API 함수 리네이밍 및 관심사 분리 방식이 괜찮은지 확인 부탁드립니다
* 댓글 등록 후 상태 전체 갱신(`fetchQnaDetail`) 방식이 괜찮을지 리뷰 요청드립니다

## ⚠️ 기타 주의 사항

* 현재 댓글 생성 API는 등록된 댓글 내용을 응답으로 내려주지 않기 때문에, 질문 상세 재조회로 댓글 갱신 처리하고 있습니다
* API가 댓글 응답 데이터를 제공하는 경우 추후 상태 최적화 고려 가능
