### PR TITLE
feat(#160) : 답변등록페이지api연동구현

### DIFF
--- a/src/api/qna/answerApi.ts
+++ b/src/api/qna/answerApi.ts
@@ -3,6 +3,7 @@ import type {
   AdoptAnswerParams,
   AdoptAnswerResponse,
   CreateCommentResponse,
+  CreateAnswerResponse,
 } from './types'
 
 export const fetchAdoptedAnswer = ({
@@ -21,5 +22,15 @@ export const createComment = (
   return post<CreateCommentResponse>(
     `/qna/questions/answers/${answer_id}/comments/`,
     { content }
+  )
+}
+
+export const createAnswer = (
+  question_id: number,
+  formData: FormData
+): Promise<CreateAnswerResponse> => {
+  return post<CreateAnswerResponse>(
+    `/qna/questions/${question_id}/answers/`,
+    formData
   )
 }

--- a/src/api/qna/types.ts
+++ b/src/api/qna/types.ts
@@ -53,3 +53,19 @@ export interface AdoptAnswerParams {
 export interface AdoptAnswerResponse {
   message: string
 }
+
+export interface CreateAnswerResponse {
+  id: number
+  question_id: number
+  author: {
+    id: number
+    nickname: string
+    profile_image_url: string
+    role: string
+  }
+  content: string
+  is_adopted: boolean
+  created_at: string
+  updated_at: string
+  comments: string[]
+}

--- a/src/components/qna/AnswerForm.tsx
+++ b/src/components/qna/AnswerForm.tsx
@@ -4,20 +4,19 @@ import MarkdownEditor from '@components/common/MarkdownEditor'
 import { useToast } from '@hooks/useToast'
 import { useAuthStore } from '@store/authStore'
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
+import { createAnswer } from '@api/qna/answerApi'
 
 interface AnswerFormProps {
   questionId: number
+  onAnswerSubmit?: () => void
 }
 
-const AnswerForm = ({ questionId }: AnswerFormProps) => {
+const AnswerForm = ({ questionId, onAnswerSubmit }: AnswerFormProps) => {
   const { user } = useAuthStore()
   const [content, setContent] = useState('')
   const [imageFiles, setImageFiles] = useState([] as File[])
   const [isReplying, setIsReplying] = useState(false)
   const toast = useToast()
-
-  const navigate = useNavigate()
 
   if (!user) {
     return null
@@ -30,24 +29,31 @@ const AnswerForm = ({ questionId }: AnswerFormProps) => {
     setImageFiles([])
     setIsReplying(false)
   }
+
   const handleSubmit = async () => {
     const formData = new FormData()
-    formData.append('content', content) // 실제 텍스트 입력
+    formData.append('content', content)
     imageFiles?.forEach((file) => {
-      formData.append('image_files', file) // 실제 File 객체 append
+      formData.append('image_files', file)
     })
+
     try {
       if (!content.trim()) {
         toast.show({ message: '답변 내용을 입력해주세요.', type: 'error' })
         return
       }
+
+      await createAnswer(questionId, formData)
+
       handleReset()
       toast.show({ message: '답변이 저장되었습니다!', type: 'success' })
-      navigate(`/qna/${questionId}`) // 답변 저장 후 해당 질문 페이지로 이동
+
+      onAnswerSubmit?.()
     } catch {
       toast.show({ message: '답변 저장 실패', type: 'error' })
     }
   }
+
   return (
     <div className="border border-gray-250 rounded-3xl mb-25">
       <div className="flex items-center justify-between py-10 px-9">

--- a/src/pages/QnaDetailPage.tsx
+++ b/src/pages/QnaDetailPage.tsx
@@ -120,6 +120,15 @@ const QnaDetailPage = () => {
     fetchData()
   }
 
+  const refreshQnaData = async () => {
+    try {
+      const response = await fetchQnaDetail(Number(questionId))
+      setQnaData(response)
+    } catch {
+      //실패무시
+    }
+  }
+
   return (
     <div className="bg-white min-h-screen px-6 py-10 max-w-4xl mx-auto">
       {/* 경로 네비게이션 */}
@@ -184,7 +193,9 @@ const QnaDetailPage = () => {
       </section>
 
       {/* 답변 요청 안내 */}
-      {user && <AnswerForm questionId={qnaData.id} />}
+      {user && (
+        <AnswerForm questionId={qnaData.id} onAnswerSubmit={refreshQnaData} />
+      )}
 
       {/* 답변 개수 */}
       <h2 className="mb-10 flex items-center gap-4 text-2xl font-semibold">


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #160

## 🔄 변경 사항

변경 사항: AnswerForm에서 useNavigate를 지우고 DetailPage에서 fetch로 불러오기작업

- [x] 기능 추가
- [x] 리팩토링


## ✔️ 변경 사항 상세 설명

useNavigate를 버리고 Detail에서 fetch 다시하기로 선택
페이지이동없이 답변이 가능하며
부드러운 UX 구현

## 📸 스크린샷 (UI 변경 시 필수)

<!-- UI 변경이 있을 경우 스크린샷을 첨부하세요 -->
<!-- 예: ![스크린샷](링크) -->

## 📝 문서화

- [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 링크 등)

## 🔍 리뷰어에게 요청 사항 (선택)

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 작성하세요 -->
<!-- 예: 에러 핸들링 방식 괜찮을지 확인 부탁드립니다. -->

## ⚠️ 기타 주의 사항

<!-- 긴급 처리 필요, 병합 순서, 의존성 등 주의 사항이 있다면 작성하세요 -->
<!-- 예: 이 PR은 hotfix이므로 빠른 병합이 필요합니다. -->
