### PR TITLE
feat(#163): 답변수정페이지 api연동작업구현

### DIFF
--- a/src/api/qna/answerApi.ts
+++ b/src/api/qna/answerApi.ts
@@ -1,9 +1,10 @@
-import { post } from '@lib/fetcher'
+import { post, put } from '@lib/fetcher'
 import type {
   AdoptAnswerParams,
   AdoptAnswerResponse,
   CreateCommentResponse,
   CreateAnswerResponse,
+  UpdateAnswerResponse,
 } from './types'
 
 export const fetchAdoptedAnswer = ({
@@ -31,6 +32,17 @@ export const createAnswer = (
 ): Promise<CreateAnswerResponse> => {
   return post<CreateAnswerResponse>(
     `/qna/questions/${question_id}/answers/`,
+    formData
+  )
+}
+
+export const updateAnswer = (
+  question_id: number,
+  answer_id: number,
+  formData: FormData
+): Promise<UpdateAnswerResponse> => {
+  return put<UpdateAnswerResponse>(
+    `/qna/questions/${question_id}/answers/${answer_id}/`,
     formData
   )
 }

--- a/src/api/qna/types.ts
+++ b/src/api/qna/types.ts
@@ -69,3 +69,19 @@ export interface CreateAnswerResponse {
   updated_at: string
   comments: string[]
 }
+
+export interface UpdateAnswerResponse {
+  id: number
+  question_id: number
+  author: {
+    id: number
+    nickname: string
+    profile_image_url: string
+    role: string
+  }
+  content: string
+  is_adopted: boolean
+  created_at: string
+  updated_at: string
+  comments: string[]
+}

--- a/src/components/qna/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard.tsx
@@ -1,6 +1,8 @@
 import SortIcon from '@assets/icons/arrow-up-down.svg'
 import Avatar from '@components/common/Avatar'
 import MarkdownRenderer from '@components/common/MarkdownEditor/MarkdownRenderer'
+import MarkdownEditor from '@components/common/MarkdownEditor'
+import { useToast } from '@hooks/useToast'
 import CommentInput from '@components/qna/CommentInput'
 import CommentList from '@components/qna/CommentList'
 import type { Answer } from '@custom-types/qnaDetail'
@@ -8,21 +10,71 @@ import { cn } from '@utils/cn'
 import { formatRelativeTime } from '@utils/formatRelativeTime'
 import { MessageCircle } from 'lucide-react'
 import { useState } from 'react'
+import Button from '@components/common/Button'
+import { useAuthStore } from '@store/authStore'
+import { updateAnswer } from '@api/qna/answerApi'
 
 interface AnswerCardProps {
   answer: Answer
+  questionId: number
   canAdopt: boolean | null
   onAdopt: (answerId: number) => void
   onAddComment: (answerId: number, text: string) => void
+  onAnswerUpdate?: () => void
 }
 
 const AnswerCard = ({
   answer,
+  questionId,
   canAdopt,
   onAdopt,
   onAddComment,
+  onAnswerUpdate,
 }: AnswerCardProps) => {
+  const { user } = useAuthStore()
+  const toast = useToast()
   const [orderByDesc, setOrderByDesc] = useState(true)
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [editContent, setEditContent] = useState(answer.content)
+  const [editImageFiles, setEditImageFiles] = useState<File[]>([])
+
+  const canEdit = user && user.nickname === answer.author.nickname
+
+  const handleStartEdit = () => {
+    setEditContent(answer.content)
+    setEditImageFiles([])
+    setIsEditing(true)
+  }
+
+  const handleCancelEdit = () => {
+    setEditContent(answer.content)
+    setEditImageFiles([])
+    setIsEditing(false)
+  }
+
+  const handleSaveEdit = async () => {
+    try {
+      if (!editContent.trim()) {
+        toast.show({ message: '답변 내용을 입력해주세요.', type: 'error' })
+        return
+      }
+
+      const formData = new FormData()
+      formData.append('content', editContent)
+      editImageFiles.forEach((file) => {
+        formData.append('image_files', file)
+      })
+
+      await updateAnswer(questionId, answer.id, formData)
+
+      toast.show({ message: '답변이 수정되었습니다!', type: 'success' })
+      setIsEditing(false)
+      onAnswerUpdate?.()
+    } catch {
+      toast.show({ message: '답변 수정 실패', type: 'error' })
+    }
+  }
 
   const sortedComments = [...answer.comments].sort((a, b) => {
     const aTime = new Date(a.created_at).getTime()
@@ -44,16 +96,46 @@ const AnswerCard = ({
         </span>
       )}
 
-      {/* 채택하기 버튼 */}
-      {canAdopt && (
-        <button
-          onClick={() => onAdopt(answer.id)}
-          className="absolute right-9 top-8 px-5 py-2 bg-primary text-white rounded-full font-semibold"
-        >
-          채택하기
-        </button>
-      )}
+      <div className="absolute right-9 top-8">
+        {/* 수정 모드일 때 버튼들 */}
+        {isEditing ? (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              className="px-4 py-2 text-xs"
+              onClick={handleCancelEdit}
+            >
+              취소
+            </Button>
+            <Button className="px-4 py-2 text-xs" onClick={handleSaveEdit}>
+              저장
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            {/* 수정 버튼 - 내가 쓴 답변에만 */}
+            {canEdit && (
+              <Button
+                variant="outline"
+                className="px-4 py-2 text-xs"
+                onClick={handleStartEdit} // 변경됨
+              >
+                답변 수정하기
+              </Button>
+            )}
 
+            {/* 채택하기 버튼 - 질문자가 다른 사람 답변에만 */}
+            {canAdopt && (
+              <Button
+                className="px-5 py-2 text-xs"
+                onClick={() => onAdopt(answer.id)}
+              >
+                채택하기
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
       {/* 답변자 정보 */}
       <div className="flex items-center gap-3 mb-4">
         <Avatar
@@ -66,7 +148,17 @@ const AnswerCard = ({
       </div>
 
       {/* 답변 본문 */}
-      <MarkdownRenderer content={answer.content} />
+      {isEditing ? (
+        <MarkdownEditor
+          placeholder="답변을 수정해주세요..."
+          value={editContent}
+          onChange={setEditContent}
+          updateImageFiles={setEditImageFiles}
+          showPreview
+        />
+      ) : (
+        <MarkdownRenderer content={answer.content} />
+      )}
 
       {/* 답변 작성일 */}
       <div className="text-gray-400 pb-5 text-right mb-10 border-b border-gray-250">

--- a/src/pages/QnaDetailPage.tsx
+++ b/src/pages/QnaDetailPage.tsx
@@ -42,7 +42,7 @@ const QnaDetailPage = () => {
       }
     }
     fetchData()
-  }, [])
+  }, [questionId, toast, navigate])
 
   const handleShare = async () => {
     try {
@@ -193,7 +193,7 @@ const QnaDetailPage = () => {
       </section>
 
       {/* 답변 요청 안내 */}
-      {user && (
+      {user && user.nickname !== qnaData.author.nickname && (
         <AnswerForm questionId={qnaData.id} onAnswerSubmit={refreshQnaData} />
       )}
 
@@ -218,9 +218,11 @@ const QnaDetailPage = () => {
           <AnswerCard
             key={answer.id}
             answer={answer}
+            questionId={qnaData.id}
             canAdopt={canAdopt}
             onAdopt={handleAdopt}
             onAddComment={handleAddComment}
+            onAnswerUpdate={refreshQnaData}
           />
         ))}
       </div>


### PR DESCRIPTION
## 🔧 관련 이슈

- 이 PR은 다음 이슈와 관련 있습니다: #163

## 🔄 변경 사항

- [x] 기능 추가
- [x] 리팩토링

## ✔️ 변경 사항 상세 설명

- 따로 수정페이지를 만들지않고 detail페이지에서 바로바로 렌더링작업
- 각 답변에 따른 채택과 수정을 위해 질문자와 채택자 분별함수작업
- 각 답변에 따른 수정시 바로바로 에디터가 열리도록 수정

## 📸 스크린샷 (UI 변경 시 필수)

<!-- UI 변경이 있을 경우 스크린샷을 첨부하세요 -->
<!-- 예: ![스크린샷](링크) -->

## 📝 문서화

- [ ] 관련 문서가 업데이트되었습니다. (`README.md`, Notion 링크 등)

## 🔍 리뷰어에게 요청 사항 (선택)

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 작성하세요 -->
<!-- 예: 에러 핸들링 방식 괜찮을지 확인 부탁드립니다. -->

## ⚠️ 기타 주의 사항

<!-- 긴급 처리 필요, 병합 순서, 의존성 등 주의 사항이 있다면 작성하세요 -->
<!-- 예: 이 PR은 hotfix이므로 빠른 병합이 필요합니다. -->
